### PR TITLE
fixed: re-add guilib api version methods

### DIFF
--- a/pvr.hts/addon.xml
+++ b/pvr.hts/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="2.1.3"
+  version="2.1.4"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp">
   <requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,4 +1,4 @@
-2.1.3
+2.1.4
 - Updated to PVR API v1.9.5
 - added: avahi discovery
 - fixed: lock on exit

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -21,6 +21,7 @@
 
 #include "client.h"
 #include "kodi/xbmc_pvr_dll.h"
+#include "kodi/libKODI_guilib.h"
 #include "kodi/threads/mutex.h"
 #include "kodi/util/atomic.h"
 #include "kodi/util/util.h"
@@ -641,6 +642,16 @@ long long LengthLiveStream(void)
 const char * GetLiveStreamURL(const PVR_CHANNEL &_unused(channel))
 {
   return "";
+}
+
+const char* GetGUIAPIVersion(void)
+{
+  return KODI_GUILIB_API_VERSION;
+}
+
+const char* GetMininumGUIAPIVersion(void)
+{
+  return KODI_GUILIB_MIN_API_VERSION;
 }
 
 } /* extern "C" */


### PR DESCRIPTION
even though there's no dep on guilib now, we still need the api version methods defined