### PR TITLE
Fix compilation error

### DIFF
--- a/src/xbmc_codec_descriptor.hpp
+++ b/src/xbmc_codec_descriptor.hpp
@@ -20,7 +20,7 @@
 #ifndef XBMC_CODEC_DESCRIPTOR_HPP
 #define	XBMC_CODEC_DESCRIPTOR_HPP
 
-#include "libXBMC_codec.h"
+#include "kodi/libXBMC_codec.h"
 
 /**
  * Adapter which converts codec names used by tvheadend and VDR into their 


### PR DESCRIPTION
[ 53%] Building CXX object CMakeFiles/pvr.hts.dir/src/HTSPDemuxer.cpp.o
In file included from /home/fli4l/br3/output/build/kodi-pvr-hts-abceaf8a6857e6ca0c7ea27f4c96e4e4a4fab92f/src/HTSPDemuxer.cpp:35:0:
/home/fli4l/br3/output/build/kodi-pvr-hts-abceaf8a6857e6ca0c7ea27f4c96e4e4a4fab92f/src/xbmc_codec_descriptor.hpp:23:27: fatal error: libXBMC_codec.h: No such file or directory
 #include "libXBMC_codec.h"
                           ^
compilation terminated.