### PR TITLE
Aligned htsp message validation with HTSP specification

### DIFF
--- a/pvr.hts/addon.xml
+++ b/pvr.hts/addon.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="2.1.4"
+  version="2.1.5"
   name="Tvheadend HTSP Client"
-  provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp">
+  provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>
     <c-pluff version="0.1"/>
     <import addon="xbmc.pvr" version="1.9.5"/>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+2.1.5
+- improved HTSP specification compliance
+
 2.1.4
 - Updated to PVR API v1.9.5
 - added: avahi discovery

--- a/src/HTSPDemuxer.cpp
+++ b/src/HTSPDemuxer.cpp
@@ -361,7 +361,7 @@ void CHTSPDemuxer::ParseMuxPacket ( htsmsg_t *m )
   if (htsmsg_get_u32(m, "stream", &idx) ||
       htsmsg_get_bin(m, "payload", &bin, &binlen))
   { 
-    tvherror("malformed muxpkt");
+    tvherror("malformed muxpkt: 'stream'/'payload' missing");
     return;
   }
 
@@ -420,7 +420,7 @@ void CHTSPDemuxer::ParseSubscriptionStart ( htsmsg_t *m )
   /* Validate */
   if ((l = htsmsg_get_list(m, "streams")) == NULL)
   {
-    tvherror("malformed subscriptionStart");
+    tvherror("malformed subscriptionStart: 'streams' missing");
     return;
   }
   m_streamStat.clear();
@@ -633,6 +633,10 @@ void CHTSPDemuxer::ParseSignalStatus ( htsmsg_t *m )
     tvhtrace("  status : %s", str);
     m_signalInfo.fe_status = str;
   }
+  else
+  {
+    tvherror("malformed signalStatus: 'feStatus' missing, ignoring");
+  }
   if (!htsmsg_get_u32(m, "feSNR", &u32))
   {
     tvhtrace("  snr    : %d", u32);
@@ -659,19 +663,35 @@ void CHTSPDemuxer::ParseTimeshiftStatus ( htsmsg_t *m )
 {
   uint32_t u32;
   int64_t s64;
-  
-  if (!htsmsg_get_u32(m, "full", &u32))
-    m_timeshiftStatus.full = (bool)u32;
-  if (!htsmsg_get_s64(m, "shift", &s64))
-    m_timeshiftStatus.shift = s64;
-  if (!htsmsg_get_s64(m, "start", &s64))
-    m_timeshiftStatus.start = s64;
-  if (!htsmsg_get_s64(m, "end", &s64))
-    m_timeshiftStatus.end = s64;
-  
+
+  /* Parse */
   tvhtrace("timeshiftStatus:");
-  tvhtrace("  full  : %d", m_timeshiftStatus.full);
-  tvhtrace("  shift : %lld", m_timeshiftStatus.shift);
-  tvhtrace("  start : %lld", m_timeshiftStatus.start);
-  tvhtrace("  end   : %lld", m_timeshiftStatus.end);
+  if (!htsmsg_get_u32(m, "full", &u32))
+  {
+    tvhtrace("  full  : %d", m_timeshiftStatus.full);
+    m_timeshiftStatus.full = (bool)u32;
+  }
+  else
+  {
+    tvherror("malformed timeshiftStatus: 'full' missing, ignoring");
+  }
+  if (!htsmsg_get_s64(m, "shift", &s64))
+  {
+    tvhtrace("  shift : %lld", m_timeshiftStatus.shift);
+    m_timeshiftStatus.shift = s64;
+  }
+  else
+  {
+    tvherror("malformed timeshiftStatus: 'shift' missing, ignoring");
+  }
+  if (!htsmsg_get_s64(m, "start", &s64))
+  {
+    tvhtrace("  start : %lld", m_timeshiftStatus.start);
+    m_timeshiftStatus.start = s64;
+  }
+  if (!htsmsg_get_s64(m, "end", &s64))
+  {
+    tvhtrace("  end   : %lld", m_timeshiftStatus.end);
+    m_timeshiftStatus.end = s64;
+  }
 }

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -442,19 +442,19 @@ private:
   /*
    * Channel/Tags/Recordings/Events
    */
-  void SyncChannelsCompleted ( void );
-  void SyncDvrCompleted      ( void );
-  void SyncEpgCompleted      ( void );
-  void SyncCompleted         ( void );
-  void ParseTagUpdate       ( htsmsg_t *m );
-  void ParseTagDelete       ( htsmsg_t *m );
-  void ParseChannelUpdate   ( htsmsg_t *m );
-  void ParseChannelDelete   ( htsmsg_t *m );
-  void ParseRecordingUpdate ( htsmsg_t *m );
-  void ParseRecordingDelete ( htsmsg_t *m );
-  void ParseEventUpdate     ( htsmsg_t *m );
-  void ParseEventDelete     ( htsmsg_t *m );
-  bool ParseEvent           ( htsmsg_t *msg, SEvent &evt );
+  void SyncChannelsCompleted     ( void );
+  void SyncDvrCompleted          ( void );
+  void SyncEpgCompleted          ( void );
+  void SyncCompleted             ( void );
+  void ParseTagAddOrUpdate       ( htsmsg_t *m, bool bAdd );
+  void ParseTagDelete            ( htsmsg_t *m );
+  void ParseChannelAddOrUpdate   ( htsmsg_t *m, bool bAdd );
+  void ParseChannelDelete        ( htsmsg_t *m );
+  void ParseRecordingAddOrUpdate ( htsmsg_t *m, bool bAdd );
+  void ParseRecordingDelete      ( htsmsg_t *m );
+  void ParseEventAddOrUpdate     ( htsmsg_t *m, bool bAdd );
+  void ParseEventDelete          ( htsmsg_t *m );
+  bool ParseEvent                ( htsmsg_t *msg, bool bAdd, SEvent &evt );
 
 public:
   /*


### PR DESCRIPTION
Revival of https://github.com/opdenkamp/xbmc-pvr-addons/pull/449

Aligned htsp message validation with HTSP spec (esp. corrected handling of optinal vs. mandatory fields).

Spec: https://tvheadend.org/projects/tvheadend/wiki/Htsp
