### PR TITLE
Update included headers

### DIFF
--- a/src/HTSPConnection.cpp
+++ b/src/HTSPConnection.cpp
@@ -20,11 +20,11 @@
  */
 
 #include "kodi/threads/mutex.h"
+#include "kodi/threads/atomics.h"
 #include "kodi/util/timeutils.h"
 #include "kodi/sockets/tcp.h"
 
 extern "C" {
-#include "kodi/util/atomic.h"
 #include "libhts/htsmsg_binary.h"
 #include "libhts/sha1.h"
 }

--- a/src/HTSPDemuxer.cpp
+++ b/src/HTSPDemuxer.cpp
@@ -23,11 +23,11 @@
 #include "client.h"
 
 #include "kodi/threads/mutex.h"
+#include "kodi/threads/atomics.h"
 #include "kodi/util/timeutils.h"
 #include "kodi/sockets/tcp.h"
 
 extern "C" {
-#include "kodi/util/atomic.h"
 #include "libhts/htsmsg_binary.h"
 #include "libhts/sha1.h"
 }

--- a/src/HTSPVFS.cpp
+++ b/src/HTSPVFS.cpp
@@ -20,11 +20,11 @@
  */
 
 #include "kodi/threads/mutex.h"
+#include "kodi/threads/atomics.h"
 #include "kodi/util/timeutils.h"
 #include "kodi/sockets/tcp.h"
 
 extern "C" {
-#include "kodi/util/atomic.h"
 #include "libhts/htsmsg_binary.h"
 #include "libhts/sha1.h"
 }

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -23,9 +23,9 @@
 #include "Tvheadend.h"
 
 #include "kodi/util/util.h"
+#include "kodi/threads/atomics.h"
 
 extern "C" {
-#include "kodi/util/atomic.h"
 #include "libhts/htsmsg_binary.h"
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -23,7 +23,7 @@
 #include "kodi/xbmc_pvr_dll.h"
 #include "kodi/libKODI_guilib.h"
 #include "kodi/threads/mutex.h"
-#include "kodi/util/atomic.h"
+#include "kodi/threads/atomics.h"
 #include "kodi/util/util.h"
 #include "Settings.h"
 #include "Tvheadend.h"


### PR DESCRIPTION
Here the same fault as on VNSI and also changed the "kodi/util/atomic.h" to "kodi/threads/atomics.h".