### PR TITLE
Fixed double free of htsp message

### DIFF
--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -291,6 +291,7 @@ PVR_ERROR CTvheadend::SendDvrUpdate( htsmsg_t* m )
   {
     tvherror("malformed updateDvrEntry response: 'success' missing");
   }
+  htsmsg_destroy(m);
 
   return u32 > 0  ? PVR_ERROR_NO_ERROR : PVR_ERROR_FAILED;
 }
@@ -490,9 +491,7 @@ PVR_ERROR CTvheadend::RenameRecording ( const PVR_RECORDING &rec )
   htsmsg_add_u32(m, "id",     atoi(rec.strRecordingId));
   htsmsg_add_str(m, "title",  rec.strTitle);
 
-  PVR_ERROR e = SendDvrUpdate(m);
-  htsmsg_destroy(m);
-  return e;
+  return SendDvrUpdate(m);
 }
 
 int CTvheadend::GetTimerCount ( void )
@@ -659,9 +658,7 @@ PVR_ERROR CTvheadend::UpdateTimer ( const PVR_TIMER &timer )
     htsmsg_add_u32(m, "priority",   (int)prio);
   }
 
-  PVR_ERROR e = SendDvrUpdate(m);
-  htsmsg_destroy(m);
-  return e;
+  return SendDvrUpdate(m);
 }
 
 /* **************************************************************************


### PR DESCRIPTION
Fixed double free of htsp message in CTvheadend::RenameRecording and CTvheadend::UpdateTimer.

Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00000000008dd737 in htsmsg_field_destroy (f=0x3d8fc70, msg=<optimized out>) at htsmsg.c:42
....
Thread 1 (Thread 0x7f9b9029a780 (LWP 1663)):
#0  0x00000000008dd737 in htsmsg_field_destroy (f=0x3d8fc70, msg=<optimized out>) at htsmsg.c:42
#1  0x00000000008dd9e1 in htsmsg_clear (msg=<optimized out>) at htsmsg.c:76
#2  htsmsg_destroy (msg=0x39cf810) at htsmsg.c:180
#3  0x00007f9b8034a48f in CTvheadend::UpdateTimer (this=0x7f9b4800e070, timer=...) at /home/kai/src/openelec/OpenELEC.tv/build.OpenELEC-Generic.x86_64-devel/kodi-pvr-add
ons-b2dc035/addons/pvr.hts/src/Tvheadend.cpp:660
#4  0x0000000000c5bda1 in PVR::CPVRClient::UpdateTimer (this=0x7f9b48005b20, timer=...) at PVRClient.cpp:986
#5  0x0000000000c60cde in PVR::CPVRClients::UpdateTimer (this=<optimized out>, timer=...) at PVRClients.cpp:412
#6  0x0000000000a674fa in PVR::CPVRTimerInfoTag::UpdateOnClient (this=0x7f9b40118400) at PVRTimerInfoTag.cpp:399
#7  0x0000000000a6a0bf in PVR::CPVRTimers::UpdateTimer (item=...) at PVRTimers.cpp:613
...