### PR TITLE
Added (actually completed) support for parental rating and star rating.

### DIFF
--- a/pvr.hts/addon.xml
+++ b/pvr.hts/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="2.1.6"
+  version="2.1.7"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,7 @@
+2.1.7
+- added: support for radio channel groups
+- added: support for star and parental rating (read only)
+
 2.1.6
 - updated to PVR API v1.9.6
 - added: support for channel group sort index

--- a/src/HTSPTypes.h
+++ b/src/HTSPTypes.h
@@ -164,8 +164,8 @@ struct SEvent
   uint32_t    content;
   time_t      start;
   time_t      stop;
-  uint32_t    stars;
-  uint32_t    age;
+  uint32_t    stars; /* 1 - 5 */
+  uint32_t    age;   /* years */
   time_t      aired;
   uint32_t    season;
   uint32_t    episode;

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -691,8 +691,8 @@ void CTvheadend::TransferEvent
   epg.iGenreSubType       = event.content & 0x0F;
   epg.strGenreDescription = NULL; /* not supported by tvh */
   epg.firstAired          = event.aired;
-  epg.iParentalRating     = 0; /* TODO: add support (seems to be only partially implemented => SEvent::age */
-  epg.iStarRating         = 0; /* TODO: add support (seems to be only partially implemented => SEvent::stars */
+  epg.iParentalRating     = event.age;
+  epg.iStarRating         = event.stars;
   epg.bNotify             = false; /* not supported by tvh */
   epg.iSeriesNumber       = event.season;
   epg.iEpisodeNumber      = event.episode;


### PR DESCRIPTION
Trivial, although info is (imo) currently not (yet?) used by Kodi.

Any objections re merging this into next pvr.hts release?  