### PR TITLE
Fix addon requiring restart no matter what settings are changed

### DIFF
--- a/pvr.hts/resources/settings.xml
+++ b/pvr.hts/resources/settings.xml
@@ -2,8 +2,8 @@
 <settings>
   <category label="30000">
 	<setting id="host" type="text" label="30001" default="127.0.0.1" />
-	<setting id="http_port" type="number" label="30002" default="9981" />
-	<setting id="htsp_port" type="number" label="30003" default="9982" />
+	<setting id="http_port" type="number" option="int" label="30002" default="9981" />
+	<setting id="htsp_port" type="number" option="int" label="30003" default="9982" />
 	<setting id="user" type="text" label="30004" default="" />
 	<setting id="pass" type="text" label="30005" option="hidden" default="" />
 	<setting id="connect_timeout" type="enum" label="30006" values="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60" default="9" />

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -203,7 +203,7 @@ ADDON_STATUS ADDON_SetSetting
 #define UPDATE_STR(key, var)\
   if (!strcmp(settingName, key))\
   {\
-    if (!strcmp(var.c_str(), (const char*)settingValue))\
+    if (strcmp(var.c_str(), (const char*)settingValue) != 0)\
     {\
       tvhdebug("update %s from '%s' to '%s'",\
                settingName, var.c_str(), settingValue);\


### PR DESCRIPTION
Two issues at play here:

* we use `type="number"` for the port settings, but without `option="int"`, the current value is sent to `ADDON_SetSetting` as a `float*` instead of `int*`, causing the comparison to fail inevitably. Changing the type to `integer` doesn't work either (even though it should), with that type the setting is not displayed in the dialog at all. See https://github.com/xbmc/xbmc/blob/master/xbmc/addons/AddonDll.h#L519

* the macro that compares if a string setting has changed was wrong, it did the exact opposite of what it was supposed to do.

@ksooo ping, and would also be great if you could runtime test this (I haven't tested at all but the changes worked fine for another addon I'm working on).