### PR TITLE
add support for reapeating timers, aka time schedules

### DIFF
--- a/src/HTSPTypes.h
+++ b/src/HTSPTypes.h
@@ -135,6 +135,8 @@ struct SRecording
   std::string      title;
   std::string      path;
   std::string      description;
+  std::string      timerecId;
+  std::string      autorecId;
   PVR_TIMER_STATE  state;
   std::string      error;
   uint32_t         retention;

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -376,6 +376,8 @@ public:
   PVR_ERROR DeleteTimer       ( const PVR_TIMER &tmr, bool force );
   PVR_ERROR UpdateTimer       ( const PVR_TIMER &tmr );
 
+  PVR_ERROR AddTimeRecording  ( const PVR_TIMER &tmr );
+
   PVR_ERROR GetEpg            ( ADDON_HANDLE handle, const PVR_CHANNEL &chn,
                                 time_t start, time_t end );
   


### PR DESCRIPTION
As series recording support probably won't be merged for Kodi 15.0, we could at least support repeating manual timers (aka time schedules in tvheadend).