### PR TITLE
Implement predictive tuning using multiple tuners

### DIFF
--- a/pvr.hts/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hts/resources/language/resource.language.en_gb/strings.po
@@ -150,3 +150,16 @@ msgctxt "#30361"
 msgid "Record max once per day"
 msgstr ""
 
+#empty strings from id 30362 to 30399
+
+msgctxt "#30400"
+msgid "Predictive tuning"
+msgstr ""
+
+msgctxt "#30401"
+msgid "Number of tuners to use"
+msgstr ""
+
+msgctxt "#30402"
+msgid "Unused subscription close delay"
+msgstr ""

--- a/pvr.hts/resources/settings.xml
+++ b/pvr.hts/resources/settings.xml
@@ -14,6 +14,11 @@
 	<setting id="epg_async" type="bool" label="30101" default="false"/>
   </category>
 
+  <category label="30400">
+	<setting id="total_tuners" type="number" option="int" label="30401" default="1" />
+	<setting id="pretuner_closedelay" type="number" option="int" label="30402" default="10" />
+  </category>
+
   <category label="30200">
 	<setting id="trace_debug" type="bool" label="30201" default="false"/>
   </category>

--- a/src/HTSPTypes.h
+++ b/src/HTSPTypes.h
@@ -63,6 +63,12 @@ enum eHTSPEventType
   HTSP_EVENT_REC_UPDATE = 4,
 };
 
+enum eSubscriptionWeight {
+  SUBSCRIPTION_WEIGHT_DEFAULT = 150,
+  SUBSCRIPTION_WEIGHT_PRETUNING = 50,
+  SUBSCRIPTION_WEIGHT_POSTTUNING = 40,
+};
+
 namespace htsp
 {
 
@@ -483,11 +489,13 @@ struct SSubscription
   uint32_t channelId;
   int      speed;
   bool     active;
+  enum eSubscriptionWeight weight;
 
   SSubscription() :
     channelId(0),
     speed (1000),
-    active(false)
+    active(false),
+    weight(SUBSCRIPTION_WEIGHT_DEFAULT)
   {
     static int previousId = 0;
     subscriptionId = ++previousId;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -35,6 +35,8 @@ namespace tvheadend {
     int         iResponseTimeout;
     bool        bTraceDebug;
     bool        bAsyncEpg;
+    int         iTotalTuners;
+    int         iPreTuneCloseDelay;
   };
 
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -55,6 +55,8 @@ string     g_strUsername         = "";
 string     g_strPassword         = "";
 bool       g_bTraceDebug         = false;
 bool       g_bAsyncEpg           = false;
+int        g_iTotalTuners        = DEFAULT_TOTAL_TUNERS;
+int        g_iPreTunerCloseDelay = DEFAULT_PRETUNER_CLOSEDELAY;
 
 /*
  * Global state
@@ -93,6 +95,8 @@ void ADDON_ReadSettings(void)
   UPDATE_INT(g_iPortHTTP,   "http_port", DEFAULT_HTTP_PORT);
   UPDATE_INT(g_iConnectTimeout,  "connect_timeout",  DEFAULT_CONNECT_TIMEOUT);
   UPDATE_INT(g_iResponseTimeout, "response_timeout", DEFAULT_RESPONSE_TIMEOUT);
+  UPDATE_INT(g_iTotalTuners,  "total_tuners",  DEFAULT_TOTAL_TUNERS);
+  UPDATE_INT(g_iPreTunerCloseDelay, "pretuner_closedelay",  DEFAULT_PRETUNER_CLOSEDELAY);
 
   /* Data Transfer */
   UPDATE_INT(g_bAsyncEpg,   "epg_async", false);
@@ -144,6 +148,9 @@ ADDON_STATUS ADDON_Create(void* hdl, void* _unused(props))
      selected value, which is zero-based, so we need to increment by one. */
   settings.iConnectTimeout = (g_iConnectTimeout + 1) * 1000;
   settings.iResponseTimeout = (g_iResponseTimeout + 1) * 1000;
+
+  settings.iTotalTuners = g_iTotalTuners;
+  settings.iPreTuneCloseDelay = g_iPreTunerCloseDelay;
 
   tvh = new CTvheadend(settings);
   tvh->Start();
@@ -249,6 +256,10 @@ ADDON_STATUS ADDON_SetSetting
 
   /* Debug */
   UPDATE_INT("trace_debug", bool, g_bTraceDebug);
+
+  /* Predictive Tuning */
+  UPDATE_INT("total_tuners", int, g_iTotalTuners);
+  UPDATE_INT("pretuner_closedelay", int, g_iPreTunerCloseDelay);
 
   return ADDON_STATUS_OK;
 

--- a/src/client.h
+++ b/src/client.h
@@ -30,11 +30,13 @@ extern ADDON::CHelper_libXBMC_addon*  XBMC;
 extern CHelper_libXBMC_pvr*           PVR;
 extern CHelper_libXBMC_codec*         CODEC;
 
-#define DEFAULT_HOST             "127.0.0.1"
-#define DEFAULT_HTTP_PORT        9981
-#define DEFAULT_HTSP_PORT        9982
-#define DEFAULT_CONNECT_TIMEOUT  10
-#define DEFAULT_RESPONSE_TIMEOUT 5
+#define DEFAULT_HOST                "127.0.0.1"
+#define DEFAULT_HTTP_PORT           9981
+#define DEFAULT_HTSP_PORT           9982
+#define DEFAULT_CONNECT_TIMEOUT     10
+#define DEFAULT_RESPONSE_TIMEOUT    5
+#define DEFAULT_TOTAL_TUNERS        1
+#define DEFAULT_PRETUNER_CLOSEDELAY 10
 
 /* timer type ids */
 #define TIMER_ONCE_MANUAL             (PVR_TIMER_TYPE_NONE + 1)


### PR DESCRIPTION
If multiple tuners are available in TVHeadend, and the addon is configured
to use them, this patch tries to anticipate the users zapping behavior, and
have the channel tuned and buffered before the channel switch happens. This
allows almost instant channel switches if the prediction was correct.

When using the default of a single tuner, the tuning behavior does not change.
If two tuners are configured, sequential up/down-zapping pre-tunes the next
channel in order; for direct channel selection the previously tuned channel
is kept to allow fast channel swapping. If more tuners are configured,
previously used channels are kept open to allow up/down tuning in any order.

The plugin uses a configurable timeout to close a predicted or previously used
channel if it does not get used, defaulting to 10s. It can be disabled by
configuring 0.

--

I have plenty of free tuners in my TVHeadend server, so I'd like to make better use of them. Im no C++ expert, nor have I any experience with the Kodi codebase, so let me know if you think something can be done simpler or cleaner. Also let me know if you want me to split up the patch to smaller changes.

The tuning prediction is currently rather simple and certainly can be improved, but it works actually very fine here for a first version.

One of the tricky points is to Trim() the input buffer correctly on anticipated/unused channels, so we don't waste memory and have just enough data so DVDPlayer doesn't need buffering. I currently use a fixed count of packets; maybe we could improve this by buffering more or less data depending on the bitrate of the channel.

We also have some room for improvements regarding subscription priority; not sure how difficult it is, but we could use a lower priority for predicted/unused streams to not interrupt other frontends using TVHeadend.