### PR TITLE
Check htsp version upon connect. Refuse to use servers with HTSP version

### DIFF
--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -2,6 +2,7 @@
 - fixed: packaging issues
 - fixed: minor issues found by static analysis
 - added: support for season/episode/part numbers for EPG tags
+- added: check htsp version upon connect. Refuse to use servers with HTSP version not matching minimal HTSP version required by client.
 
 2.1.8
 - added: support for epg subtitles, aka episode names

--- a/pvr.hts/resources/language/English/strings.po
+++ b/pvr.hts/resources/language/English/strings.po
@@ -69,3 +69,9 @@ msgstr ""
 msgctxt "#30201"
 msgid "Trace (detailed)"
 msgstr ""
+
+#empty strings from id 30202 to 30299
+
+msgctxt "#30300"
+msgid "HTSP version mismatch (supported: v%d, required: v%d). Please update tvheadend."
+msgstr ""

--- a/src/HTSPConnection.cpp
+++ b/src/HTSPConnection.cpp
@@ -473,6 +473,16 @@ void CHTSPConnection::Register ( void )
       goto fail;
     }
 
+    /* Check htsp server version against client minimum htsp version */
+    if (m_htspVersion < HTSP_API_VERSION)
+    {
+      tvherror("server htsp version (v%d) does not match minimum htsp version required by client (v%d)", m_htspVersion, HTSP_API_VERSION);
+      Disconnect();
+      m_ready = false;
+      m_regCond.Broadcast();
+      return;
+    }
+
     /* Send Auth */
     tvhdebug("sending auth");
     
@@ -536,7 +546,7 @@ void* CHTSPConnection::Process ( void )
     tvhtrace("waiting for connection...");
     if (!m_socket->Open(timeout))
     {
-      /* Unable to connect, inform the user */
+      /* Unable to connect */
       tvherror("unable to connect to %s:%d", host.c_str(), port);
       
       // Retry a few times with a short interval, after that with the default timeout

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -485,6 +485,10 @@ public:
   {
     return m_conn.GetServerString();
   }
+  inline int GetProtocol ( void ) const
+  {
+    return m_conn.GetProtocol();
+  }
   inline bool HasCapability(const std::string &capability) const
   {
       return m_conn.HasCapability(capability);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -148,11 +148,19 @@ ADDON_STATUS ADDON_Create(void* hdl, void* _unused(props))
   tvh->Start();
 
   /* Wait for connection */
-  if (!tvh->WaitForConnection()) {
+  if (!tvh->WaitForConnection())
+  {
+    if (tvh->GetProtocol() < HTSP_API_VERSION)
+    {
+      /* client/server API version mismatch */
+      XBMC->QueueNotification(QUEUE_ERROR, XBMC->GetLocalizedString(30300), tvh->GetProtocol(), HTSP_API_VERSION);
+    }
+
     SAFE_DELETE(tvh);
     SAFE_DELETE(PVR);
     SAFE_DELETE(CODEC);
     SAFE_DELETE(XBMC);
+
     return ADDON_STATUS_LOST_CONNECTION;
   }
 


### PR DESCRIPTION
not matching minimal HTSP version required by client.

This one gets important once the series recording changes in pvr.hts get merged as those changes require a recent tvheadend (at least 4.0.0, HTSP v20). Staying compatible with ancient tvheadend 3.4 (HTSP v12) forever imo makes no sense and would clutter code with dozens of protocol checks. It's time to tell users it's time for an update of tvheadend, esp. as tvh4 is (kinda?) official release.

I'd like to get this PR in for Isengard's pvr.hts.