### PR TITLE
add Provides section to debian/control to fix upgrade path from

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Conflicts: kodi-pvr-tvheadend-hts
 Replaces: kodi-pvr-tvheadend-hts
+Provides: kodi-pvr-hts, kodi-pvr-tvheadend-hts
 Description: TVHeadEnd PVR for Kodi
  TVHeadEnd PVR for Kodi
 

--- a/pvr.hts/addon.xml
+++ b/pvr.hts/addon.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="2.1.15"
+  version="2.1.16"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+2.1.16
+- fixed: Debian/Ubuntu package didn't properly replace the package name previously used
+
 2.1.15
 - fixed: recordings from older tvheadend versions weren't displayed
 


### PR DESCRIPTION
Helix versions due to a change in the package name

@wsnipex can you rebuild the PPA version once this is in?