### PR TITLE
Fix timer Start/End clocks showing incorrect time after 'save'

### DIFF
--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -3,6 +3,7 @@
 - added: implementation of GetBufferTimeStart and GetBufferTimeEnd (timeshifting).
 - fixed: Coverity warnings introduced by predictive tuning feature.
 - fixed: Autorec: Start and stop time handling.
+- fixed: LocaltimeToUTC conversion (timer settings clock display incorrect)
 
 2.2.4
 - added: Predictive tuning (thanks @martinwilli)

--- a/src/HTSPTypes.cpp
+++ b/src/HTSPTypes.cpp
@@ -279,12 +279,8 @@ time_t RecordingBase::LocaltimeToUTC(int32_t lctime)
   tm_time->tm_hour  = lctime / 60;
   tm_time->tm_min   = lctime % 60;
   tm_time->tm_sec   = 0;
-  tm_time->tm_isdst = 0;
 
-  t = mktime(tm_time);
-
-  /* convert to UTC. */
-  return mktime(gmtime(&t));
+  return mktime(tm_time);
 }
 
 // static


### PR DESCRIPTION
This fix works only if the tvheadend server and kodi are in the same timezone.
Servers in different timezones must therefore be considered unsupported.

The proper fix for this is https://github.com/kodi-pvr/pvr.hts/pull/85 which uses gmt offset from the server, however currently on several linux platforms which use vanilla glibc (debian/openElec + others) tvheadend fails to include any DST offset in the value returned.