### PR TITLE
Fix: Use epg data only for creation of epg-based timers.

### DIFF
--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,11 +1,12 @@
 2.2.5
 - dropped CStdString usage
-- added: implementation of GetBufferTimeStart and GetBufferTimeEnd (timeshifting).
+- added: Implementation of GetBufferTimeStart and GetBufferTimeEnd (timeshifting).
 - fixed: Coverity warnings introduced by predictive tuning feature.
 - fixed: Autorec: Start and stop time handling.
-- fixed: LocaltimeToUTC conversion (timer settings clock display incorrect)
+- fixed: LocaltimeToUTC conversion (timer settings clock display incorrect).
 - fixed: Several issues with predictive tuning.
-- added: Automatically fill in platform and library name
+- added: build: Automatically fill in platform and library name.
+- fixed: Use epg data only for creation of epg-based timers.
 
 2.2.4
 - added: Predictive tuning (thanks @martinwilli)

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -841,7 +841,7 @@ PVR_ERROR CTvheadend::AddTimer ( const PVR_TIMER &timer )
 
     /* Build message */
     htsmsg_t *m = htsmsg_create_map();
-    if (timer.iEpgUid > 0)
+    if (timer.iEpgUid > 0 && timer.iTimerType == TIMER_ONCE_EPG)
     {
       /* EPG-based timer */
       htsmsg_add_u32(m, "eventId",      timer.iEpgUid);


### PR DESCRIPTION
This is actually an ancient bug that can easily fixed be now that we have timer types. More details here: https://github.com/xbmc/xbmc/pull/7782

@Jalle19 Any objections?