### PR TITLE
Improve connection handling on suspend/wakeup.

### DIFF
--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -7,6 +7,7 @@
 - fixed: Several issues with predictive tuning.
 - added: build: Automatically fill in platform and library name.
 - fixed: Use epg data only for creation of epg-based timers.
+- improved: Do not try to reconnect to tvh while suspending or not fully awake again.
 
 2.2.4
 - added: Predictive tuning (thanks @martinwilli)

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -199,6 +199,9 @@ public:
   bool        WaitForConnection ( void );
 
   inline PLATFORM::CMutex& Mutex ( void ) { return m_mutex; }
+
+  void        OnSleep ( void );
+  void        OnWake  ( void );
   
 private:
   void*       Process          ( void );
@@ -222,6 +225,8 @@ private:
 
   CHTSPResponseList                   m_messages;
   std::vector<std::string>            m_capabilities;
+
+  bool                                m_suspended;
 };
 
 /*
@@ -543,7 +548,7 @@ public:
   }
   inline bool HasCapability(const std::string &capability) const
   {
-      return m_conn.HasCapability(capability);
+    return m_conn.HasCapability(capability);
   }
   inline bool IsConnected ( void ) const
   {
@@ -552,6 +557,14 @@ public:
   inline void Disconnect ( void )
   {
     m_conn.Disconnect();
+  }
+  inline void OnSleep ( void )
+  {
+    m_conn.OnSleep();
+  }
+  inline void OnWake ( void )
+  {
+    m_conn.OnWake();
   }
 
   /*

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -284,9 +284,10 @@ void ADDON_Announce
   /* XBMC/System */
   if (!strcmp(sender, "xbmc") && !strcmp(flag, "System"))
   {
-    /* Wake - close connection (it'll most likely need remaking) */
-    if (!strcmp("OnWake", message))
-      tvh->Disconnect();
+    if (!strcmp("OnSleep", message))
+      tvh->OnSleep();
+    else if (!strcmp("OnWake", message))
+      tvh->OnWake();
   }
 }
 


### PR DESCRIPTION
This is an old patch I have on my private build for about a year now.

Today, on system suspend, pvr.hts looses connection to tvh (socket closed) and immediately retries to reconnect, even though suspend is in progress and the attempt cannot succeed. This results in error log messages while suspending and a non-deterministic behaviour after resume. This PR fixes this problem by preventing reconnects as long as pvr.hts is "suspended".

@Jalle19 objections?