### PR TITLE
Force cmake to configure addon.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ if(WIN32)
   list(APPEND DEPLIBS ws2_32)
 endif()
 
+configure_file(pvr.hts/addon.xml.in ${CMAKE_CURRENT_SOURCE_DIR}/pvr.hts/addon.xml)
 build_addon(pvr.hts HTS DEPLIBS)
 
 include(CPack)


### PR DESCRIPTION
The current source code only includes addon.xml.in whereas build_addon
etc need a valid .xml file. To resolve this, addon.xml.in needs to be
copied using CMake's configure_file.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>