### PR TITLE
workaround: playback of active recordings

### DIFF
--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -396,7 +396,8 @@ PVR_ERROR CTvheadend::GetRecordings ( ADDON_HANDLE handle )
       }
 
       /* EPG event id */
-      rec.iEpgEventId = rit->second.eventId;
+      /* workaround: causes high cpu usage */
+      //rec.iEpgEventId = rit->second.eventId;
 
       recs.push_back(rec);
     }


### PR DESCRIPTION
People are suffering from a bug that causes recordings to stutter:
http://forum.kodi.tv/showthread.php?tid=234640

This bug (in kodi) is triggered by the epg event id, which is only used by tvh and not by other addons at the moment. 
A fix is in the make for v16: https://github.com/xbmc/xbmc/pull/7905

So I suggest to just disable the event id for Isengard..

@Jalle19 @ksooo 
