### PR TITLE
Setting for Autorec start window behavior & settings rework

### DIFF
--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -2,6 +2,8 @@
 - Updated to PVR API v4.1.0
 - simplified recording playback handling, fixes random skipping to the beginning of recordings
 - fixed: recordings from channels that have been deleted since were not available in Kodi
+- added: setting for start time window calculation (autorec)
+- simplified addon settings 
 
 2.2.7
 - Updated to PVR API v4.0.0

--- a/pvr.hts/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hts/resources/language/resource.language.en_gb/strings.po
@@ -19,7 +19,7 @@ msgstr ""
 #settings labels
 
 msgctxt "#30000"
-msgid "Connection Settings"
+msgid "Connection settings"
 msgstr ""
 
 msgctxt "#30001"
@@ -43,14 +43,18 @@ msgid "Password"
 msgstr ""
 
 msgctxt "#30006"
-msgid "Connection timeout in seconds"
+msgid "Connection timeout (seconds)"
 msgstr ""
 
 msgctxt "#30007"
-msgid "Response timeout in seconds"
+msgid "Response timeout (seconds)"
 msgstr ""
 
-#empty strings from id 30008 to 30049
+msgctxt "#30008"
+msgid "Advanced settings"
+msgstr ""
+
+#empty strings from id 30009 to 30049
 
 msgctxt "#30050"
 msgid "Auto recordings"
@@ -69,13 +73,13 @@ msgid "Relaxed (start time +/- margin)"
 msgstr ""
 
 msgctxt "#30054"
-msgid "Maximum start time margin (mins)"
+msgid "Maximum start time margin (minutes)"
 msgstr ""
 
 #empty strings from id 30055 to 30099
 
 msgctxt "#30100"
-msgid "Data Transfer"
+msgid "Data transfer"
 msgstr ""
 
 msgctxt "#30101"

--- a/pvr.hts/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hts/resources/language/resource.language.en_gb/strings.po
@@ -50,7 +50,29 @@ msgctxt "#30007"
 msgid "Response timeout in seconds"
 msgstr ""
 
-#empty strings from id 30008 to 30099
+#empty strings from id 30008 to 30049
+
+msgctxt "#30050"
+msgid "Auto recordings"
+msgstr ""
+
+msgctxt "#30051"
+msgid "Start time window calculation"
+msgstr ""
+
+msgctxt "#30052"
+msgid "Strict (start time + end time)"
+msgstr ""
+
+msgctxt "#30053"
+msgid "Relaxed (start time +/- margin)"
+msgstr ""
+
+msgctxt "#30054"
+msgid "Maximum start time margin (mins)"
+msgstr ""
+
+#empty strings from id 30055 to 30099
 
 msgctxt "#30100"
 msgid "Data Transfer"

--- a/pvr.hts/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hts/resources/language/resource.language.en_gb/strings.po
@@ -187,5 +187,9 @@ msgid "Number of subscriptions to use"
 msgstr ""
 
 msgctxt "#30402"
-msgid "Unused subscription close delay"
+msgid "Unused subscription close delay (seconds)"
+msgstr ""
+
+msgctxt "#30403"
+msgid "Use predictive tuning to speedup channel switches"
 msgstr ""

--- a/pvr.hts/resources/settings.xml
+++ b/pvr.hts/resources/settings.xml
@@ -16,8 +16,9 @@
     <setting id="autorec_maxdiff" enable="eq(-1,1)"  type="slider" option="int" range="0,5,120" label="30054" default="15" />
     
     <setting label="30400" type="lsep"/>
-    <setting id="total_tuners" type="number" option="int" label="30401" default="1" />
-    <setting id="pretuner_closedelay" type="number" option="int" label="30402" default="10" />
+    <setting id="pretuner_enabled" type="bool" label="30403" default="false" />
+    <setting id="total_tuners" enable="eq(-1,true)" type="slider" option="int" range="2,1,10" label="30401"  default="2" />
+    <setting id="pretuner_closedelay" enable="eq(-2,true)" type="slider" option="int" range="5,5,60" label="30402" default="10" />
     
     <setting label="30100" type="lsep"/>
     <setting id="epg_async" type="bool" label="30101" default="false"/>

--- a/pvr.hts/resources/settings.xml
+++ b/pvr.hts/resources/settings.xml
@@ -10,13 +10,18 @@
 	<setting id="response_timeout" type="enum" label="30007" values="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60" default="4" />
   </category>
 
+  <category label="30050">
+	<setting id="autorec_approxtime" type="enum" label="30051" lvalues="30052|30053" default="0"/>
+	<setting id="autorec_maxdiff" enable="eq(-1,1)"  type="slider" option="int" range="0,5,120" label="30054" default="15" />
+  </category>
+  
   <category label="30100">
 	<setting id="epg_async" type="bool" label="30101" default="false"/>
   </category>
 
   <category label="30400">
 	<setting id="total_tuners" type="number" option="int" label="30401" default="1" />
-	<setting id="pretuner_closedelay" type="number" option="int" label="30402" default="10" />
+	<setting id="pretuner_closedelay" type="number" option="int" label="30402" subsetting="true" default="10" />
   </category>
 
   <category label="30200">

--- a/pvr.hts/resources/settings.xml
+++ b/pvr.hts/resources/settings.xml
@@ -5,26 +5,25 @@
 	<setting id="http_port" type="number" option="int" label="30002" default="9981" />
 	<setting id="htsp_port" type="number" option="int" label="30003" default="9982" />
 	<setting id="user" type="text" label="30004" default="" />
-	<setting id="pass" type="text" label="30005" option="hidden" default="" />
-	<setting id="connect_timeout" type="enum" label="30006" values="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60" default="9" />
-	<setting id="response_timeout" type="enum" label="30007" values="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60" default="4" />
+	<setting id="pass" type="text" label="30005" option="hidden" enable="!eq(-1,)" default="" />
+	<setting id="connect_timeout" type="slider" option="int" range="1,60" label="30006" default="10" />
+	<setting id="response_timeout" type="slider" option="int" range="1,60" label="30007" default="5" />
   </category>
 
-  <category label="30050">
-	<setting id="autorec_approxtime" type="enum" label="30051" lvalues="30052|30053" default="0"/>
-	<setting id="autorec_maxdiff" enable="eq(-1,1)"  type="slider" option="int" range="0,5,120" label="30054" default="15" />
+  <category label="30008">
+    <setting label="30050" type="lsep"/>
+    <setting id="autorec_approxtime" type="enum" label="30051" lvalues="30052|30053" default="0"/>
+    <setting id="autorec_maxdiff" enable="eq(-1,1)"  type="slider" option="int" range="0,5,120" label="30054" default="15" />
+    
+    <setting label="30400" type="lsep"/>
+    <setting id="total_tuners" type="number" option="int" label="30401" default="1" />
+    <setting id="pretuner_closedelay" type="number" option="int" label="30402" default="10" />
+    
+    <setting label="30100" type="lsep"/>
+    <setting id="epg_async" type="bool" label="30101" default="false"/>
+    
+    <setting label="30200" type="lsep"/>
+    <setting id="trace_debug" type="bool" label="30201" default="false"/>
   </category>
   
-  <category label="30100">
-	<setting id="epg_async" type="bool" label="30101" default="false"/>
-  </category>
-
-  <category label="30400">
-	<setting id="total_tuners" type="number" option="int" label="30401" default="1" />
-	<setting id="pretuner_closedelay" type="number" option="int" label="30402" subsetting="true" default="10" />
-  </category>
-
-  <category label="30200">
-	<setting id="trace_debug" type="bool" label="30201" default="false"/>
-  </category>
 </settings>

--- a/src/HTSPTypes.h
+++ b/src/HTSPTypes.h
@@ -211,10 +211,10 @@ public:
   bool operator!=(const AutoRecording &right);
 
   time_t GetStart() const;
-  void SetStart(int32_t start);
+  void SetStartWindowBegin(int32_t begin);
 
   time_t GetStop() const;
-  void SetStop(int32_t stop);
+  void SetStartWindowEnd(int32_t end);
 
   int64_t GetMarginStart() const;
   void SetMarginStart(int64_t startExtra);
@@ -229,8 +229,8 @@ public:
   void SetFulltext(uint32_t fulltext);
 
 private:
-  int32_t  m_start;       // Exact start time (minutes from midnight).
-  int32_t  m_startWindow; // Exact stop time (minutes from midnight).
+  int32_t  m_startWindowBegin; // Begin of the starting window (minutes from midnight).
+  int32_t  m_startWindowEnd;   // End of the starting window (minutes from midnight).
   int64_t  m_startExtra;  // Extra start minutes (pre-time).
   int64_t  m_stopExtra;   // Extra stop minutes (post-time).
   uint32_t m_dupDetect;   // duplicate episode detect (record: 0 = all, 1 = different episode number,

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -37,6 +37,8 @@ namespace tvheadend {
     bool        bAsyncEpg;
     int         iTotalTuners;
     int         iPreTuneCloseDelay;
+    bool        bAutorecApproxTime;
+    int         iAutorecMaxDiff;
   };
 
 }

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -691,9 +691,7 @@ PVR_ERROR CTvheadend::GetTimerTypes ( PVR_TIMER_TYPE types[], int *size )
         PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH    |
         PVR_TIMER_TYPE_SUPPORTS_CHANNELS           |
         PVR_TIMER_TYPE_SUPPORTS_START_TIME         |
-        PVR_TIMER_TYPE_SUPPORTS_END_TIME           |
         PVR_TIMER_TYPE_SUPPORTS_START_ANYTIME      |
-        PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME        |
         PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS           |
         PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN   |
         PVR_TIMER_TYPE_SUPPORTS_PRIORITY           |
@@ -704,6 +702,13 @@ PVR_ERROR CTvheadend::GetTimerTypes ( PVR_TIMER_TYPE types[], int *size )
     {
       TIMER_REPEATING_EPG_ATTRIBS |= PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH;
       TIMER_REPEATING_EPG_ATTRIBS |= PVR_TIMER_TYPE_SUPPORTS_RECORD_ONLY_NEW_EPISODES;
+    }
+
+    if (!m_settings.bAutorecApproxTime)
+    {
+      /* We need the end time to represent the end of the tvh starting window */
+      TIMER_REPEATING_EPG_ATTRIBS |= PVR_TIMER_TYPE_SUPPORTS_END_TIME;
+      TIMER_REPEATING_EPG_ATTRIBS |= PVR_TIMER_TYPE_SUPPORTS_END_ANYTIME;
     }
 
     timerTypes.push_back(

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -57,6 +57,8 @@ bool       g_bTraceDebug         = false;
 bool       g_bAsyncEpg           = false;
 int        g_iTotalTuners        = DEFAULT_TOTAL_TUNERS;
 int        g_iPreTunerCloseDelay = DEFAULT_PRETUNER_CLOSEDELAY;
+int        g_iAutorecApproxTime  = DEFAULT_APPROX_TIME;
+int        g_iAutorecMaxDiff     = DEFAULT_AUTOREC_MAXDIFF;
 
 /*
  * Global state
@@ -103,6 +105,10 @@ void ADDON_ReadSettings(void)
 
   /* Debug */
   UPDATE_INT(g_bTraceDebug, "trace_debug", false);
+
+  /* Auto recordings */
+  UPDATE_INT(g_iAutorecApproxTime, "autorec_approxtime", DEFAULT_APPROX_TIME);
+  UPDATE_INT(g_iAutorecMaxDiff, "autorec_maxdiff", DEFAULT_AUTOREC_MAXDIFF);
 
   /* TODO: Transcoding */
 
@@ -151,6 +157,9 @@ ADDON_STATUS ADDON_Create(void* hdl, void* _unused(props))
 
   settings.iTotalTuners = g_iTotalTuners;
   settings.iPreTuneCloseDelay = g_iPreTunerCloseDelay;
+
+  settings.bAutorecApproxTime = (g_iAutorecApproxTime > 0);
+  settings.iAutorecMaxDiff = g_iAutorecMaxDiff;
 
   tvh = new CTvheadend(settings);
   tvh->Start();
@@ -260,6 +269,10 @@ ADDON_STATUS ADDON_SetSetting
   /* Predictive Tuning */
   UPDATE_INT("total_tuners", int, g_iTotalTuners);
   UPDATE_INT("pretuner_closedelay", int, g_iPreTunerCloseDelay);
+
+  /* Auto Recordings */
+  UPDATE_INT("autorec_approxtime", int, g_iAutorecApproxTime);
+  UPDATE_INT("autorec_maxdiff", int, g_iAutorecMaxDiff);
 
   return ADDON_STATUS_OK;
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -149,11 +149,9 @@ ADDON_STATUS ADDON_Create(void* hdl, void* _unused(props))
   settings.bTraceDebug = g_bTraceDebug;
   settings.bAsyncEpg = g_bAsyncEpg;
 
-  /* Timeouts are defined in seconds but we expect them to be in milliseconds. 
-     Furthermore, the value from the settings is actually the index of the 
-     selected value, which is zero-based, so we need to increment by one. */
-  settings.iConnectTimeout = (g_iConnectTimeout + 1) * 1000;
-  settings.iResponseTimeout = (g_iResponseTimeout + 1) * 1000;
+  /* Timeouts are defined in seconds but we expect them to be in milliseconds. */
+  settings.iConnectTimeout = (g_iConnectTimeout * 1000);
+  settings.iResponseTimeout = (g_iResponseTimeout * 1000);
 
   settings.iTotalTuners = g_iTotalTuners;
   settings.iPreTuneCloseDelay = g_iPreTunerCloseDelay;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -55,6 +55,7 @@ string     g_strUsername         = "";
 string     g_strPassword         = "";
 bool       g_bTraceDebug         = false;
 bool       g_bAsyncEpg           = false;
+bool       g_bPreTunerEnabled    = false;
 int        g_iTotalTuners        = DEFAULT_TOTAL_TUNERS;
 int        g_iPreTunerCloseDelay = DEFAULT_PRETUNER_CLOSEDELAY;
 int        g_iAutorecApproxTime  = DEFAULT_APPROX_TIME;
@@ -99,6 +100,7 @@ void ADDON_ReadSettings(void)
   UPDATE_INT(g_iResponseTimeout, "response_timeout", DEFAULT_RESPONSE_TIMEOUT);
   UPDATE_INT(g_iTotalTuners,  "total_tuners",  DEFAULT_TOTAL_TUNERS);
   UPDATE_INT(g_iPreTunerCloseDelay, "pretuner_closedelay",  DEFAULT_PRETUNER_CLOSEDELAY);
+  UPDATE_INT(g_bPreTunerEnabled, "pretuner_enabled", false);
 
   /* Data Transfer */
   UPDATE_INT(g_bAsyncEpg,   "epg_async", false);
@@ -153,8 +155,17 @@ ADDON_STATUS ADDON_Create(void* hdl, void* _unused(props))
   settings.iConnectTimeout = (g_iConnectTimeout * 1000);
   settings.iResponseTimeout = (g_iResponseTimeout * 1000);
 
-  settings.iTotalTuners = g_iTotalTuners;
-  settings.iPreTuneCloseDelay = g_iPreTunerCloseDelay;
+  if (g_bPreTunerEnabled)
+  {
+    settings.iTotalTuners = g_iTotalTuners;
+    settings.iPreTuneCloseDelay = g_iPreTunerCloseDelay;
+  }
+  else
+  {
+    /* When we don't want to use predictive tuning */
+    settings.iTotalTuners = 1;
+    settings.iPreTuneCloseDelay = 0;
+  }
 
   settings.bAutorecApproxTime = (g_iAutorecApproxTime > 0);
   settings.iAutorecMaxDiff = g_iAutorecMaxDiff;
@@ -267,6 +278,7 @@ ADDON_STATUS ADDON_SetSetting
   /* Predictive Tuning */
   UPDATE_INT("total_tuners", int, g_iTotalTuners);
   UPDATE_INT("pretuner_closedelay", int, g_iPreTunerCloseDelay);
+  UPDATE_INT("pretuner_enabled", bool, g_bPreTunerEnabled);
 
   /* Auto Recordings */
   UPDATE_INT("autorec_approxtime", int, g_iAutorecApproxTime);

--- a/src/client.h
+++ b/src/client.h
@@ -38,6 +38,10 @@ extern CHelper_libXBMC_codec*         CODEC;
 #define DEFAULT_TOTAL_TUNERS        1
 #define DEFAULT_PRETUNER_CLOSEDELAY 10
 
+/* Maximum difference between real and approximate start time for auto recordings (minutes) */
+#define DEFAULT_AUTOREC_MAXDIFF      15
+#define DEFAULT_APPROX_TIME          0
+
 /* timer type ids */
 #define TIMER_ONCE_MANUAL             (PVR_TIMER_TYPE_NONE + 1)
 #define TIMER_ONCE_EPG                (PVR_TIMER_TYPE_NONE + 2)


### PR DESCRIPTION
1) Added setting for the autorec start window behavior:
I disabled end time for when this setting is enabled, strictly speaking autorecs don't have an end time in tvh.
2) Reworked settings as there where lot's of categories and user could input invalid integers.

![schermafdruk van 2015-09-16 20 56 49](https://cloud.githubusercontent.com/assets/2036512/9915146/b23c79b2-5cb5-11e5-845a-7793664c5319.png)
![schermafdruk van 2015-09-16 20 56 22](https://cloud.githubusercontent.com/assets/2036512/9915147/b246884e-5cb5-11e5-8d57-eb99e3cb9b85.png)


@PhobosK, @Jalle19, @ksooo 
