### PR TITLE
Attempt to fix #92

### DIFF
--- a/src/CircBuffer.cpp
+++ b/src/CircBuffer.cpp
@@ -67,6 +67,7 @@ void CCircBuffer::unalloc(void)
 void CCircBuffer::reset(void)
 {
   CLockObject lock(m_mutex);
+  memset(m_buffer, 0, m_alloc);
   m_pin   = 0;
   m_pout  = 0;
   m_count = 0;

--- a/src/HTSPVFS.cpp
+++ b/src/HTSPVFS.cpp
@@ -178,6 +178,8 @@ long long CHTSPVFS::Seek ( long long pos, int whence )
   CLockObject lock(m_conn.Mutex());
   if (m_fileId == 0)
     return -1;
+  m_buffer.reset();
+  m_bHasData = false;
   m_bSeekDone = false;
   return SendFileSeek(pos, whence);
 }

--- a/src/HTSPVFS.cpp
+++ b/src/HTSPVFS.cpp
@@ -178,8 +178,6 @@ long long CHTSPVFS::Seek ( long long pos, int whence )
   CLockObject lock(m_conn.Mutex());
   if (m_fileId == 0)
     return -1;
-  m_buffer.reset();
-  m_bHasData = false;
   m_bSeekDone = false;
   return SendFileSeek(pos, whence);
 }


### PR DESCRIPTION
Issue #92 seems to be caused by data in the buffer left after a previous seek. This fix is by no means the most elegant solution, but clearing the whole buffer seems to fix the issue. All credits go to @Glenn-1990, I merely tested his ideas.