### PR TITLE
Update to PVR addon API v4.1.0

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="2.2.7"
+  version="2.2.8"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.0.0"/>
+    <import addon="xbmc.pvr" version="4.1.0"/>
     <import addon="xbmc.codec" version="1.0.1"/>
   </requires>
   <extension

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+2.2.8
+- Updated to PVR API v4.1.0
+
 2.2.7
 - Updated to PVR API v4.0.0
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1045,6 +1045,7 @@ void CTvheadend::TransferEvent
   epg.iEpisodeNumber      = event.episode;
   epg.iEpisodePartNumber  = event.part;
   epg.strEpisodeName      = event.subtitle.c_str();
+  epg.iFlags              = EPG_TAG_FLAG_UNDEFINED;
 
   /* Callback. */
   PVR->TransferEpgEntry(handle, &epg);


### PR DESCRIPTION
This PR implements all changes needed to properly support PVR Addon API v4.1.0, including a PVR addon micro version bump.

Details can be found here: xbmc/xbmc#8075