### PR TITLE
Recordings: add support for episode name (aka subtitle)

### DIFF
--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -3,7 +3,8 @@
 - simplified recording playback handling, fixes random skipping to the beginning of recordings
 - fixed: recordings from channels that have been deleted since were not available in Kodi
 - added: setting for start time window calculation (autorec)
-- simplified addon settings 
+- simplified addon settings
+- added: support for episode name (subtitle) for recordings
 
 2.2.7
 - Updated to PVR API v4.0.0

--- a/src/HTSPTypes.h
+++ b/src/HTSPTypes.h
@@ -281,6 +281,7 @@ struct SRecording
   int64_t          startExtra;
   int64_t          stopExtra;
   std::string      title;
+  std::string      subtitle; /* episode name */
   std::string      path;
   std::string      description;
   std::string      timerecId;

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -376,6 +376,9 @@ PVR_ERROR CTvheadend::GetRecordings ( ADDON_HANDLE handle )
       /* Title */
       strncpy(rec.strTitle, rit->second.title.c_str(), sizeof(rec.strTitle) - 1);
 
+      /* Subtitle */
+      strncpy(rec.strEpisodeName, rit->second.subtitle.c_str(), sizeof(rec.strEpisodeName) - 1);
+
       /* Description */
       strncpy(rec.strPlot, rit->second.description.c_str(), sizeof(rec.strPlot) - 1);
 
@@ -1820,6 +1823,10 @@ void CTvheadend::ParseRecordingAddOrUpdate ( htsmsg_t *msg, bool bAdd )
   if ((str = htsmsg_get_str(msg, "title")) != NULL)
   {
     UPDATE(rec.title, str);
+  }
+  if ((str = htsmsg_get_str(msg, "subtitle")) != NULL)
+  {
+    UPDATE(rec.subtitle, str);
   }
   if ((str = htsmsg_get_str(msg, "path")) != NULL)
   {


### PR DESCRIPTION
PVR_RECORDING.strEpisodeName was added with PVR Addon API 3.0.0
"subtitle" field was added to method dvrEntryAdd with HTSP version 20
=> Let's make something useful out of this. ;-)