### PR TITLE
Add support for streaming profiles

### DIFF
--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,6 +1,7 @@
 2.2.9
 - refactored the code by factoring out lots of things into separate files
 - refactored the Settings class into a singleton to avoid having to include client.h everywhere
+- added: support for specifying which streaming profile to use
 
 2.2.8
 - Updated to PVR API v4.1.0

--- a/pvr.hts/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hts/resources/language/resource.language.en_gb/strings.po
@@ -225,3 +225,19 @@ msgstr ""
 msgctxt "#30456"
 msgid "Subscription error"
 msgstr ""
+
+#empty strings from id 30456 to 30499
+
+msgctxt "#30500"
+msgid "Streaming"
+msgstr ""
+
+msgctxt "#30501"
+msgid "Streaming profile to use"
+msgstr ""
+
+#. Check streaming profile validity during startup
+#: src/client.cpp
+msgctxt "#30502"
+msgid "Streaming profile %s is not available"
+msgstr ""

--- a/pvr.hts/resources/settings.xml
+++ b/pvr.hts/resources/settings.xml
@@ -15,6 +15,9 @@
     <setting id="autorec_approxtime" type="enum" label="30051" lvalues="30052|30053" default="0"/>
     <setting id="autorec_maxdiff" enable="eq(-1,1)"  type="slider" option="int" range="0,5,120" label="30054" default="15" />
     
+    <setting label="30500" type="lsep"/>
+    <setting id="streaming_profile" type="text" label="30501" default="" />
+
     <setting label="30400" type="lsep"/>
     <setting id="pretuner_enabled" type="bool" label="30403" default="false" />
     <setting id="total_tuners" enable="eq(-1,true)" type="slider" option="int" range="2,1,10" label="30401"  default="2" />

--- a/src/HTSPDemuxer.cpp
+++ b/src/HTSPDemuxer.cpp
@@ -224,6 +224,11 @@ PVR_ERROR CHTSPDemuxer::CurrentSignal ( PVR_SIGNAL_STATUS &sig )
   return PVR_ERROR_NO_ERROR;
 }
 
+void CHTSPDemuxer::SetStreamingProfile(const std::string &profile)
+{
+  m_subscription.SetProfile(profile);
+}
+
 /* **************************************************************************
  * Parse incoming data
  * *************************************************************************/

--- a/src/HTSPTypes.h
+++ b/src/HTSPTypes.h
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <vector>
 #include <map>
+#include <string>
 #include "client.h"
 
 typedef enum {

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -165,6 +165,16 @@ bool CTvheadend::HasStreamingProfile(const std::string &streamingProfile) const
   ) != m_profiles.cend();
 }
 
+std::string CTvheadend::GetStreamingProfile() const
+{
+  std::string streamingProfile;
+
+  if (HasStreamingProfile(Settings::GetInstance().GetStreamingProfile()))
+    streamingProfile = Settings::GetInstance().GetStreamingProfile();
+
+  return streamingProfile;
+}
+
 /* **************************************************************************
  * Tags
  * *************************************************************************/
@@ -1416,6 +1426,12 @@ void CTvheadend::SyncCompleted ( void )
     XBMC->QueueNotification(
         QUEUE_ERROR,
         XBMC->GetLocalizedString(30502), streamingProfile.c_str());
+  }
+  else
+  {
+    /* Tell each demuxer to use this profile from now on */
+    for (auto *dmx : m_dmx)
+      dmx->SetStreamingProfile(streamingProfile);
   }
 }
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -153,6 +153,18 @@ void CTvheadend::QueryAvailableProfiles()
   htsmsg_destroy(m);
 }
 
+bool CTvheadend::HasStreamingProfile(const std::string &streamingProfile) const
+{
+  return std::find_if(
+      m_profiles.cbegin(),
+      m_profiles.cend(),
+      [&streamingProfile](const Profile &profile)
+      {
+        return profile.GetName() == streamingProfile;
+      }
+  ) != m_profiles.cend();
+}
+
 /* **************************************************************************
  * Tags
  * *************************************************************************/
@@ -1392,6 +1404,19 @@ void CTvheadend::SyncCompleted ( void )
   SyncDvrCompleted();
   SyncEpgCompleted();
   m_asyncState.SetState(ASYNC_DONE);
+
+  /* Query the server for available streaming profiles */
+  QueryAvailableProfiles();
+
+  /* Show a notification if the profile is not available */
+  std::string streamingProfile = Settings::GetInstance().GetStreamingProfile();
+
+  if (!streamingProfile.empty() && !HasStreamingProfile(streamingProfile))
+  {
+    XBMC->QueueNotification(
+        QUEUE_ERROR,
+        XBMC->GetLocalizedString(30502), streamingProfile.c_str());
+  }
 }
 
 void CTvheadend::SyncChannelsCompleted ( void )

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -33,6 +33,7 @@
 #include "HTSPTypes.h"
 #include "AsyncState.h"
 #include "tvheadend/ChannelTuningPredictor.h"
+#include "tvheadend/Profile.h"
 #include "tvheadend/entity/Tag.h"
 #include "tvheadend/entity/Channel.h"
 #include "tvheadend/entity/Recording.h"
@@ -401,12 +402,23 @@ public:
 
   PVR_ERROR GetEpg            ( ADDON_HANDLE handle, const PVR_CHANNEL &chn,
                                 time_t start, time_t end );
+
+  /**
+   * Queries the server for available streaming profiles and populates
+   * m_profiles
+   */
+  void QueryAvailableProfiles();
   
 private:
   bool      CreateTimer       ( const tvheadend::entity::Recording &tvhTmr, PVR_TIMER &tmr );
 
   uint32_t GetNextUnnumberedChannelNumber ();
   std::string GetImageURL     ( const char *str );
+
+  /**
+   * The streaming profiles available on the server
+   */
+  tvheadend::Profiles         m_profiles;
 
   PLATFORM::CMutex            m_mutex;
 

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -403,17 +403,23 @@ public:
   PVR_ERROR GetEpg            ( ADDON_HANDLE handle, const PVR_CHANNEL &chn,
                                 time_t start, time_t end );
 
-  /**
-   * Queries the server for available streaming profiles and populates
-   * m_profiles
-   */
-  void QueryAvailableProfiles();
-  
 private:
   bool      CreateTimer       ( const tvheadend::entity::Recording &tvhTmr, PVR_TIMER &tmr );
 
   uint32_t GetNextUnnumberedChannelNumber ();
   std::string GetImageURL     ( const char *str );
+
+  /**
+   * Queries the server for available streaming profiles and populates
+   * m_profiles
+   */
+  void QueryAvailableProfiles();
+
+  /**
+   * @param streamingProfile the streaming profile to check for
+   * @return whether the server supports the specified streaming profile
+   */
+  bool HasStreamingProfile(const std::string &streamingProfile) const;
 
   /**
    * The streaming profiles available on the server

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -284,6 +284,12 @@ public:
     return 0;
   }
 
+  /**
+   * Tells each demuxer to use the specified profile for new subscriptions
+   * @param profile the profile to use
+   */
+  void SetStreamingProfile(const std::string &profile);
+
 private:
   PLATFORM::CMutex                        m_mutex;
   CHTSPConnection                        &m_conn;
@@ -420,6 +426,12 @@ private:
    * @return whether the server supports the specified streaming profile
    */
   bool HasStreamingProfile(const std::string &streamingProfile) const;
+
+  /**
+   * @return the streaming profile to use for new subscriptions, or an
+   *         empty string if no particular profile should be used
+   */
+  std::string GetStreamingProfile() const;
 
   /**
    * The streaming profiles available on the server

--- a/src/tvheadend/Profile.h
+++ b/src/tvheadend/Profile.h
@@ -1,0 +1,66 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2015 Team Kodi
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+#include <vector>
+
+namespace tvheadend
+{
+
+  class Profile;
+  typedef std::vector<Profile> Profiles;
+
+  /**
+   * Represents a single streaming profile
+   */
+  class Profile
+  {
+  public:
+
+    std::string GetUuid() const { return m_uuid; }
+    void SetUuid(const std::string &uuid) { m_uuid = uuid; }
+
+    std::string GetName() const { return m_name; }
+    void SetName(const std::string &name) { m_name = name; }
+
+    std::string GetComment() const { return m_comment; }
+    void SetComment(const std::string &comment) { m_comment = comment; }
+
+  private:
+    /*
+     * The profile UUID
+     */
+    std::string m_uuid;
+
+    /**
+     * The profile name
+     */
+    std::string m_name;
+
+    /**
+     * The profile comment
+     */
+    std::string m_comment;
+  };
+
+}

--- a/src/tvheadend/Settings.cpp
+++ b/src/tvheadend/Settings.cpp
@@ -38,6 +38,7 @@ const int         Settings::DEFAULT_TOTAL_TUNERS        = 1;  // total tuners > 
 const int         Settings::DEFAULT_PRETUNER_CLOSEDELAY = 10; // secs
 const int         Settings::DEFAULT_AUTOREC_MAXDIFF     = 15; // mins. Maximum difference between real and approximate start time for auto recordings
 const int         Settings::DEFAULT_APPROX_TIME         = 0;  // mins
+const std::string Settings::DEFAULT_STREAMING_PROFILE   = "";
 
 void Settings::ReadSettings()
 {
@@ -66,6 +67,9 @@ void Settings::ReadSettings()
   /* Auto recordings */
   SetAutorecApproxTime(ReadIntSetting("autorec_approxtime", DEFAULT_APPROX_TIME));
   SetAutorecMaxDiff(ReadIntSetting("autorec_maxdiff", DEFAULT_AUTOREC_MAXDIFF));
+
+  /* Streaming */
+  SetStreamingProfile(ReadStringSetting("streaming_profile", DEFAULT_STREAMING_PROFILE));
 }
 
 ADDON_STATUS Settings::SetSetting(const std::string &key, const void *value)
@@ -108,6 +112,9 @@ ADDON_STATUS Settings::SetSetting(const std::string &key, const void *value)
     return SetIntSetting(GetAutorecApproxTime(), value);
   else if (key == "autorec_maxdiff")
     return SetIntSetting(GetAutorecMaxDiff(), value);
+  /* Streaming */
+  else if (key == "streaming_profile")
+    return SetStringSetting(GetStreamingProfile(), value);
   else
   {
     tvherror("Settings::SetSetting - unknown setting '%s'", key.c_str());

--- a/src/tvheadend/Settings.h
+++ b/src/tvheadend/Settings.h
@@ -47,6 +47,7 @@ namespace tvheadend {
     static const int         DEFAULT_PRETUNER_CLOSEDELAY; // secs
     static const int         DEFAULT_AUTOREC_MAXDIFF; // mins. Maximum difference between real and approximate start time for auto recordings
     static const int         DEFAULT_APPROX_TIME;     // mins
+    static const std::string DEFAULT_STREAMING_PROFILE;
 
     /**
      * Singleton getter for the instance
@@ -84,6 +85,7 @@ namespace tvheadend {
     int         GetPreTunerCloseDelay() const { return m_iPreTunerCloseDelay; }
     bool        GetAutorecApproxTime() const { return m_bAutorecApproxTime; }
     int         GetAutorecMaxDiff() const { return m_iPreTunerCloseDelay; }
+    std::string GetStreamingProfile() const { return m_strStreamingProfile; }
 
   private:
     Settings()
@@ -99,7 +101,8 @@ namespace tvheadend {
       m_iTotalTuners(DEFAULT_TOTAL_TUNERS),
       m_iPreTunerCloseDelay(DEFAULT_PRETUNER_CLOSEDELAY),
       m_bAutorecApproxTime(DEFAULT_APPROX_TIME),
-      m_iAutorecMaxDiff(DEFAULT_AUTOREC_MAXDIFF) {}
+      m_iAutorecMaxDiff(DEFAULT_AUTOREC_MAXDIFF),
+      m_strStreamingProfile{DEFAULT_STREAMING_PROFILE} {}
 
     Settings(Settings const &) = delete;
     void operator=(Settings const &) = delete;
@@ -120,6 +123,7 @@ namespace tvheadend {
     void SetPreTunerCloseDelay(int value) { m_iPreTunerCloseDelay = value; }
     void SetAutorecApproxTime(bool value) { m_bAutorecApproxTime = value; }
     void SetAutorecMaxDiff(int value) { m_iAutorecMaxDiff = value; }
+    void SetStreamingProfile(const std::string &value) { m_strStreamingProfile = value; }
 
     /**
      * Read/Set values according to definition in settings.xml
@@ -146,6 +150,7 @@ namespace tvheadend {
     int         m_iPreTunerCloseDelay;
     bool        m_bAutorecApproxTime;
     int         m_iAutorecMaxDiff;
+    std::string m_strStreamingProfile;
   };
 
 }

--- a/src/tvheadend/Subscription.cpp
+++ b/src/tvheadend/Subscription.cpp
@@ -101,6 +101,18 @@ void Subscription::SetState(eSubsriptionState state)
   m_state = state;
 }
 
+std::string Subscription::GetProfile() const
+{
+  CLockObject lock(m_mutex);
+  return m_profile;
+}
+
+void Subscription::SetProfile(const std::string &profile)
+{
+  CLockObject lock(m_mutex);
+  m_profile = profile;
+}
+
 void Subscription::SendSubscribe(uint32_t channelId, uint32_t weight, bool restart)
 {
   /* We don't want to change anything when restarting a subscription */
@@ -120,6 +132,11 @@ void Subscription::SendSubscribe(uint32_t channelId, uint32_t weight, bool resta
   htsmsg_add_u32(m, "timeshiftPeriod", static_cast<uint32_t>(~0));
   htsmsg_add_u32(m, "normts",          1);
   htsmsg_add_u32(m, "queueDepth",      PACKET_QUEUE_DEPTH);
+
+  /* Use the specified profile if it has been set */
+  if (!GetProfile().empty())
+    htsmsg_add_str(m, "profile", GetProfile().c_str());
+
   tvhdebug("demux subscribe to %d",    GetChannelId());
 
   /* Send and Wait for response */

--- a/src/tvheadend/Subscription.h
+++ b/src/tvheadend/Subscription.h
@@ -21,6 +21,7 @@
  *
  */
 
+#include <string>
 #include "platform/threads/mutex.h"
 
 extern "C"
@@ -71,6 +72,7 @@ namespace tvheadend
     uint32_t          GetWeight() const;
     int32_t           GetSpeed() const;
     eSubsriptionState GetState() const;
+    std::string       GetProfile() const;
 
     /**
      * Subscribe to a channel on the backend
@@ -78,7 +80,9 @@ namespace tvheadend
      * @param weight the desired subscription weight
      * @param restart restart the current subscription (i.e. after lost connection), other parameters will be ignored
      */
-    void SendSubscribe(uint32_t channelId = 0, uint32_t weight = SUBSCRIPTION_WEIGHT_NORMAL, bool restart = false);
+    void SendSubscribe(uint32_t channelId = 0,
+                       uint32_t weight = SUBSCRIPTION_WEIGHT_NORMAL,
+                       bool restart = false);
 
     /**
      * Unsubscribe from a channel on the backend
@@ -111,6 +115,12 @@ namespace tvheadend
      */
     void ParseSubscriptionStatus(htsmsg_t *m);
 
+    /**
+     * Use the specified profile for all new subscriptions
+     * @param profile the profile
+     */
+    void SetProfile(const std::string &profile);
+
   private:
 
     void SetId(uint32_t id);
@@ -134,6 +144,7 @@ namespace tvheadend
     uint32_t          m_weight;
     int32_t           m_speed;
     eSubsriptionState m_state;
+    std::string       m_profile;
     CHTSPConnection   &m_conn;
 
     mutable PLATFORM::CMutex  m_mutex;


### PR DESCRIPTION
See #40 

@ksooo for review. I've split the feature into three commits for easier review, we can squash it before merging if you want to.

I'm thinking whether we should add another boolean option to disable predictive tuning if a streaming profile is set. Having multiple transcoded subscriptions can easily overwhelm a low-powered server.

Since this touches settings I'd like to get #116 merged before this one. #79 would be nice to get in before as well since it refactors `Subscription` into a class (if the feature is not ready we could opt for just merging that particular part).

@TheTroll can you test this?