### PR TITLE
Parse subscriptionError also for dvr entries

### DIFF
--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1750,6 +1750,19 @@ void CTvheadend::ParseRecordingAddOrUpdate ( htsmsg_t *msg, bool bAdd )
       rec.SetError(str);
   }
   
+  /* A running recording will have an active subscription assigned to it */
+  if (rec.GetState() == PVR_TIMER_STATE_RECORDING)
+  {
+    /* Parse subscription error */
+    /* This field is absent when everything is fine or when htsp version < 20 */
+    if ((str = htsmsg_get_str(msg, "subscriptionError")) != NULL)
+    {
+      /* No free adapter, AKA subscription conflict */
+      if (!strcmp("noFreeAdapter", str))
+        rec.SetState(PVR_TIMER_STATE_CONFLICT_NOK);
+    }
+  }
+
   /* Update */
   if (rec != comparison)
   {

--- a/src/tvheadend/entity/Recording.h
+++ b/src/tvheadend/entity/Recording.h
@@ -93,13 +93,15 @@ namespace tvheadend
       {
         return m_state == PVR_TIMER_STATE_COMPLETED ||
                m_state == PVR_TIMER_STATE_ABORTED ||
-               m_state == PVR_TIMER_STATE_RECORDING;
+               m_state == PVR_TIMER_STATE_RECORDING ||
+               m_state == PVR_TIMER_STATE_CONFLICT_NOK;
       }
 
       bool IsTimer() const
       {
         return m_state == PVR_TIMER_STATE_SCHEDULED ||
-               m_state == PVR_TIMER_STATE_RECORDING;
+               m_state == PVR_TIMER_STATE_RECORDING ||
+               m_state == PVR_TIMER_STATE_CONFLICT_NOK;
       }
 
       /**


### PR DESCRIPTION
Currently when an active recording isn't running because there is no free adapter available,
kodi will still show the timer as 'recording' (status field in timers window).

Now, for active recordings we can parse 'subscriptionError' as each active recording will have an active subscription. If 'subscriptionError' returns 'noFreeAdapter' we flag the timer state to 'PVR_TIMER_STATE_CONFLICT_NOK' and kodi will show 'conflict' as status in the timers window now.

No free adapter is practically the same as a conflict in my eyes..

Additionally we could also parse the other errors like scrambled, no signal etc and show them as error in the kodi GUI, what do you think?
https://github.com/xbmc/xbmc/blob/master/xbmc/addons/include/xbmc_pvr_types.h#L192