### PR TITLE
Replace the tvhxxx() macros with a separate logger utility

### DIFF
--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -8,6 +8,7 @@
 - fixed: restart subscription after a connection restore
 - fixed: allow to abort active recordings also for timers created by timerec and autorec
 - fixed: enable/disable of timers created by timerec and autorec (HTSP v23 and above)
+- refactored the logging utility from a bunch of macros to a class
 
 2.2.9
 - refactored the code by factoring out lots of things into separate files

--- a/src/AutoRecordings.cpp
+++ b/src/AutoRecordings.cpp
@@ -24,10 +24,12 @@
 #include "Tvheadend.h"
 #include "tvheadend/Settings.h"
 #include "tvheadend/utilities/Utilities.h"
+#include "tvheadend/utilities/Logger.h"
 
 using namespace PLATFORM;
 using namespace tvheadend;
 using namespace tvheadend::entity;
+using namespace tvheadend::utilities;
 
 AutoRecordings::AutoRecordings(CHTSPConnection &conn) :
   m_conn(conn)
@@ -132,7 +134,7 @@ const unsigned int AutoRecordings::GetTimerIntIdFromStringId(const std::string &
     if (tit->second.GetStringId() == strId)
       return tit->second.GetId();
   }
-  tvherror("Autorec: Unable to obtain int id for string id %s", strId.c_str());
+  Logger::Log(LogLevel::ERROR, "Autorec: Unable to obtain int id for string id %s", strId.c_str());
   return 0;
 }
 
@@ -238,7 +240,7 @@ PVR_ERROR AutoRecordings::SendAutorecAdd(const PVR_TIMER &timer)
   /* Check for error */
   if (htsmsg_get_u32(m, "success", &u32))
   {
-    tvherror("malformed addAutorecEntry response: 'success' missing");
+    Logger::Log(LogLevel::ERROR, "malformed addAutorecEntry response: 'success' missing");
     u32 = PVR_ERROR_FAILED;
   }
   htsmsg_destroy(m);
@@ -287,7 +289,7 @@ PVR_ERROR AutoRecordings::SendAutorecDelete(const PVR_TIMER &timer)
   /* Check for error */
   if (htsmsg_get_u32(m, "success", &u32))
   {
-    tvherror("malformed deleteAutorecEntry response: 'success' missing");
+    Logger::Log(LogLevel::ERROR, "malformed deleteAutorecEntry response: 'success' missing");
   }
   htsmsg_destroy(m);
 
@@ -304,7 +306,7 @@ bool AutoRecordings::ParseAutorecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   /* Validate/set mandatory fields */
   if ((str = htsmsg_get_str(msg, "id")) == NULL)
   {
-    tvherror("malformed autorecEntryAdd/autorecEntryUpdate: 'id' missing");
+    Logger::Log(LogLevel::ERROR, "malformed autorecEntryAdd/autorecEntryUpdate: 'id' missing");
     return false;
   }
 
@@ -321,7 +323,7 @@ bool AutoRecordings::ParseAutorecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed autorecEntryAdd: 'enabled' missing");
+    Logger::Log(LogLevel::ERROR, "malformed autorecEntryAdd: 'enabled' missing");
     return false;
   }
 
@@ -331,7 +333,7 @@ bool AutoRecordings::ParseAutorecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed autorecEntryAdd: 'retention' missing");
+    Logger::Log(LogLevel::ERROR, "malformed autorecEntryAdd: 'retention' missing");
     return false;
   }
 
@@ -341,7 +343,7 @@ bool AutoRecordings::ParseAutorecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd && (m_conn.GetProtocol() >= 24))
   {
-    tvherror("malformed autorecEntryAdd: 'removal' missing");
+    Logger::Log(LogLevel::ERROR, "malformed autorecEntryAdd: 'removal' missing");
     return false;
   }
 
@@ -351,7 +353,7 @@ bool AutoRecordings::ParseAutorecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed autorecEntryAdd: 'daysOfWeek' missing");
+    Logger::Log(LogLevel::ERROR, "malformed autorecEntryAdd: 'daysOfWeek' missing");
     return false;
   }
 
@@ -361,7 +363,7 @@ bool AutoRecordings::ParseAutorecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed autorecEntryAdd: 'priority' missing");
+    Logger::Log(LogLevel::ERROR, "malformed autorecEntryAdd: 'priority' missing");
     return false;
   }
 
@@ -371,7 +373,7 @@ bool AutoRecordings::ParseAutorecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed autorecEntryAdd: 'start' missing");
+    Logger::Log(LogLevel::ERROR, "malformed autorecEntryAdd: 'start' missing");
     return false;
   }
 
@@ -381,7 +383,7 @@ bool AutoRecordings::ParseAutorecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed autorecEntryAdd: 'startWindow' missing");
+    Logger::Log(LogLevel::ERROR, "malformed autorecEntryAdd: 'startWindow' missing");
     return false;
   }
 
@@ -391,7 +393,7 @@ bool AutoRecordings::ParseAutorecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed autorecEntryAdd: 'startExtra' missing");
+    Logger::Log(LogLevel::ERROR, "malformed autorecEntryAdd: 'startExtra' missing");
     return false;
   }
 
@@ -401,7 +403,7 @@ bool AutoRecordings::ParseAutorecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed autorecEntryAdd: 'stopExtra' missing");
+    Logger::Log(LogLevel::ERROR, "malformed autorecEntryAdd: 'stopExtra' missing");
     return false;
   }
 
@@ -411,7 +413,7 @@ bool AutoRecordings::ParseAutorecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd && (m_conn.GetProtocol() >= 20))
   {
-    tvherror("malformed autorecEntryAdd: 'dupDetect' missing");
+    Logger::Log(LogLevel::ERROR, "malformed autorecEntryAdd: 'dupDetect' missing");
     return false;
   }
 
@@ -461,10 +463,10 @@ bool AutoRecordings::ParseAutorecDelete(htsmsg_t *msg)
   /* Validate/set mandatory fields */
   if ((id = htsmsg_get_str(msg, "id")) == NULL)
   {
-    tvherror("malformed autorecEntryDelete: 'id' missing");
+    Logger::Log(LogLevel::ERROR, "malformed autorecEntryDelete: 'id' missing");
     return false;
   }
-  tvhtrace("delete autorec entry %s", id);
+  Logger::Log(LogLevel::TRACE, "delete autorec entry %s", id);
 
   /* Erase */
   m_autoRecordings.erase(std::string(id));

--- a/src/TimeRecordings.cpp
+++ b/src/TimeRecordings.cpp
@@ -23,10 +23,12 @@
 
 #include "Tvheadend.h"
 #include "tvheadend/utilities/Utilities.h"
+#include "tvheadend/utilities/Logger.h"
 
 using namespace PLATFORM;
 using namespace tvheadend;
 using namespace tvheadend::entity;
+using namespace tvheadend::utilities;
 
 TimeRecordings::TimeRecordings(CHTSPConnection &conn) :
   m_conn(conn)
@@ -107,7 +109,7 @@ const unsigned int TimeRecordings::GetTimerIntIdFromStringId(const std::string &
     if (tit->second.GetStringId() == strId)
       return tit->second.GetId();
   }
-  tvherror("Timerec: Unable to obtain int id for string id %s", strId.c_str());
+  Logger::Log(LogLevel::ERROR, "Timerec: Unable to obtain int id for string id %s", strId.c_str());
   return 0;
 }
 
@@ -155,7 +157,7 @@ PVR_ERROR TimeRecordings::SendTimerecAdd(const PVR_TIMER &timer)
   /* Check for error */
   if (htsmsg_get_u32(m, "success", &u32))
   {
-    tvherror("malformed addTimerecEntry response: 'success' missing");
+    Logger::Log(LogLevel::ERROR, "malformed addTimerecEntry response: 'success' missing");
     u32 = PVR_ERROR_FAILED;
   }
   htsmsg_destroy(m);
@@ -204,7 +206,7 @@ PVR_ERROR TimeRecordings::SendTimerecDelete(const PVR_TIMER &timer)
   /* Check for error */
   if (htsmsg_get_u32(m, "success", &u32))
   {
-    tvherror("malformed deleteTimerecEntry response: 'success' missing");
+    Logger::Log(LogLevel::ERROR, "malformed deleteTimerecEntry response: 'success' missing");
   }
   htsmsg_destroy(m);
 
@@ -220,7 +222,7 @@ bool TimeRecordings::ParseTimerecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   /* Validate/set mandatory fields */
   if ((str = htsmsg_get_str(msg, "id")) == NULL)
   {
-    tvherror("malformed timerecEntryAdd/timerecEntryUpdate: 'id' missing");
+    Logger::Log(LogLevel::ERROR, "malformed timerecEntryAdd/timerecEntryUpdate: 'id' missing");
     return false;
   }
 
@@ -237,7 +239,7 @@ bool TimeRecordings::ParseTimerecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed timerecEntryAdd: 'enabled' missing");
+    Logger::Log(LogLevel::ERROR, "malformed timerecEntryAdd: 'enabled' missing");
     return false;
   }
 
@@ -247,7 +249,7 @@ bool TimeRecordings::ParseTimerecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed timerecEntryAdd: 'daysOfWeek' missing");
+    Logger::Log(LogLevel::ERROR, "malformed timerecEntryAdd: 'daysOfWeek' missing");
     return false;
   }
 
@@ -257,7 +259,7 @@ bool TimeRecordings::ParseTimerecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed timerecEntryAdd: 'retention' missing");
+    Logger::Log(LogLevel::ERROR, "malformed timerecEntryAdd: 'retention' missing");
     return false;
   }
 
@@ -267,7 +269,7 @@ bool TimeRecordings::ParseTimerecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd && (m_conn.GetProtocol() >= 24))
   {
-    tvherror("malformed timerecEntryAdd: 'removal' missing");
+    Logger::Log(LogLevel::ERROR, "malformed timerecEntryAdd: 'removal' missing");
     return false;
   }
 
@@ -277,7 +279,7 @@ bool TimeRecordings::ParseTimerecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed timerecEntryAdd: 'priority' missing");
+    Logger::Log(LogLevel::ERROR, "malformed timerecEntryAdd: 'priority' missing");
     return false;
   }
 
@@ -287,7 +289,7 @@ bool TimeRecordings::ParseTimerecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed timerecEntryAdd: 'start' missing");
+    Logger::Log(LogLevel::ERROR, "malformed timerecEntryAdd: 'start' missing");
     return false;
   }
 
@@ -297,7 +299,7 @@ bool TimeRecordings::ParseTimerecAddOrUpdate(htsmsg_t *msg, bool bAdd)
   }
   else if (bAdd)
   {
-    tvherror("malformed timerecEntryAdd: 'stop' missing");
+    Logger::Log(LogLevel::ERROR, "malformed timerecEntryAdd: 'stop' missing");
     return false;
   }
 
@@ -342,10 +344,10 @@ bool TimeRecordings::ParseTimerecDelete(htsmsg_t *msg)
   /* Validate/set mandatory fields */
   if ((id = htsmsg_get_str(msg, "id")) == NULL)
   {
-    tvherror("malformed timerecEntryDelete: 'id' missing");
+    Logger::Log(LogLevel::ERROR, "malformed timerecEntryDelete: 'id' missing");
     return false;
   }
-  tvhtrace("delete timerec entry %s", id);
+  Logger::Log(LogLevel::TRACE, "delete timerec entry %s", id);
 
   /* Erase */
   m_timeRecordings.erase(std::string(id));

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -78,24 +78,6 @@ extern "C" {
 #define INVALID_SEEKTIME           (-1)
 
 /*
- * Log wrappers
- */
-#define tvhdebug(...) tvhlog(ADDON::LOG_DEBUG, ##__VA_ARGS__)
-#define tvhinfo(...)  tvhlog(ADDON::LOG_INFO,  ##__VA_ARGS__)
-#define tvherror(...) tvhlog(ADDON::LOG_ERROR, ##__VA_ARGS__)
-#define tvhtrace(...) if (tvheadend::Settings::GetInstance().GetTraceDebug()) tvhlog(ADDON::LOG_DEBUG, ##__VA_ARGS__)
-static inline void tvhlog ( ADDON::addon_log_t lvl, const char *fmt, ... )
-{
-  char buf[16384];
-  int c = sprintf(buf, "pvr.hts - ");
-  va_list va;
-  va_start(va, fmt);
-  vsnprintf(buf + c, sizeof(buf) - c, fmt, va);
-  va_end(va);
-  XBMC->Log(lvl, "%s", buf);
-}
-
-/*
  * Forward decleration of classes
  */
 class CHTSPConnection;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -84,7 +84,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* _unused(props))
   }
 
   /* Configure the logger */
-  Logger::SetImplementation([](LogLevel level, const char *message)
+  Logger::GetInstance().SetImplementation([](LogLevel level, const char *message)
   {
     /* Convert the log level */
     addon_log_t addonLevel;
@@ -107,6 +107,8 @@ ADDON_STATUS ADDON_Create(void* hdl, void* _unused(props))
 
     XBMC->Log(addonLevel, message);
   });
+
+  Logger::GetInstance().SetPrefix("pvr.hts");
 
   Logger::Log(LogLevel::INFO, "starting PVR client");
 

--- a/src/tvheadend/Settings.cpp
+++ b/src/tvheadend/Settings.cpp
@@ -19,11 +19,12 @@
  *
  */
 
-#include "../Tvheadend.h"
-
+#include "utilities/Logger.h"
+#include "../client.h"
 #include "Settings.h"
 
-namespace tvheadend {
+using namespace tvheadend;
+using namespace tvheadend::utilities;
 
 const std::string Settings::DEFAULT_HOST                = "127.0.0.1";
 const int         Settings::DEFAULT_HTTP_PORT           = 9981;
@@ -148,7 +149,7 @@ ADDON_STATUS Settings::SetSetting(const std::string &key, const void *value)
     return SetIntSetting(GetDvrDupdetect(), value);
   else
   {
-    tvherror("Settings::SetSetting - unknown setting '%s'", key.c_str());
+    Logger::Log(LogLevel::ERROR, "Settings::SetSetting - unknown setting '%s'", key.c_str());
     return ADDON_STATUS_UNKNOWN;
   }
 }
@@ -245,5 +246,3 @@ int Settings::GetDvrLifetime(bool asEnum) const
     }
   }
 }
-
-} // namespace tvheadend

--- a/src/tvheadend/utilities/Logger.h
+++ b/src/tvheadend/utilities/Logger.h
@@ -42,7 +42,7 @@ namespace tvheadend
     /**
      * Short-hand for a function that acts as the logger implementation
      */
-    typedef std::function<void(LogLevel level, const char *message)> LogImplementation;
+    typedef std::function<void(LogLevel level, const char *message)> LoggerImplementation;
 
     /**
      * The logger class. It is a singleton that by default comes with no
@@ -54,6 +54,16 @@ namespace tvheadend
     public:
 
       /**
+       * Returns the singleton instance
+       * @return
+       */
+      static Logger &GetInstance()
+      {
+        static Logger instance;
+        return instance;
+      }
+
+      /**
        * Logs the specified message using the specified log level
        * @param level the log level
        * @param message the log message
@@ -61,24 +71,31 @@ namespace tvheadend
        */
       static void Log(LogLevel level, const std::string &message, ...)
       {
+        auto &logger = GetInstance();
+
         char buffer[MESSAGE_BUFFER_SIZE];
-        std::string logMessage = "pvr.hts - " + message;
+        std::string logMessage = message;
+        std::string prefix = logger.m_prefix;
+
+        // Prepend the prefix when set
+        if (!prefix.empty())
+          logMessage = prefix + " - " + message;
 
         va_list arguments;
         va_start(arguments, message);
         vsprintf(buffer, logMessage.c_str(), arguments);
         va_end(arguments);
 
-        GetInstance().m_implementation(level, buffer);
+        logger.m_implementation(level, buffer);
       }
 
       /**
        * Configures the logger to use the specified implementation
        * @þaram implementation lambda
        */
-      static void SetImplementation(LogImplementation implementation)
+      void SetImplementation(LoggerImplementation implementation)
       {
-        GetInstance().m_implementation = implementation;
+        m_implementation = implementation;
       }
 
     private:
@@ -88,18 +105,14 @@ namespace tvheadend
       { };
 
       /**
-       * @return the instance
-       */
-      static Logger &GetInstance()
-      {
-        static Logger instance;
-        return instance;
-      }
-
-      /**
        * The logger implementation
        */
-      LogImplementation m_implementation;
+      LoggerImplementation m_implementation;
+
+      /**
+       * The log message prefix
+       */
+      std::string m_prefix;
 
     };
   }

--- a/src/tvheadend/utilities/Logger.h
+++ b/src/tvheadend/utilities/Logger.h
@@ -1,0 +1,106 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2015 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+#include <memory>
+#include <cstdarg>
+
+namespace tvheadend
+{
+  namespace utilities
+  {
+    /**
+     * Represents the log level
+     */
+    enum LogLevel
+    {
+      ERROR,
+      INFO,
+      DEBUG,
+      TRACE
+    };
+
+    /**
+     * Short-hand for a function that acts as the logger implementation
+     */
+    typedef std::function<void(LogLevel level, const char *message)> LogImplementation;
+
+    /**
+     * The logger class. It is a singleton that by default comes with no
+     * underlying implementation. It is up to the user to supply a suitable
+     * implementation as a lambda using SetImplementation().
+     */
+    class Logger
+    {
+    public:
+
+      /**
+       * Logs the specified message using the specified log level
+       * @param level the log level
+       * @param message the log message
+       * @param ... parameters for the log message
+       */
+      static void Log(LogLevel level, const std::string &message, ...)
+      {
+        char buffer[MESSAGE_BUFFER_SIZE];
+        std::string logMessage = "pvr.hts - " + message;
+
+        va_list arguments;
+        va_start(arguments, message);
+        vsprintf(buffer, logMessage.c_str(), arguments);
+        va_end(arguments);
+
+        GetInstance().m_implementation(level, buffer);
+      }
+
+      /**
+       * Configures the logger to use the specified implementation
+       * @þaram implementation lambda
+       */
+      static void SetImplementation(LogImplementation implementation)
+      {
+        GetInstance().m_implementation = implementation;
+      }
+
+    private:
+      static const unsigned int MESSAGE_BUFFER_SIZE = 16384;
+
+      Logger()
+      { };
+
+      /**
+       * @return the instance
+       */
+      static Logger &GetInstance()
+      {
+        static Logger instance;
+        return instance;
+      }
+
+      /**
+       * The logger implementation
+       */
+      LogImplementation m_implementation;
+
+    };
+  }
+}


### PR DESCRIPTION
@ksooo here it is. I'm not particularly proud of using a private singleton for storing the implementation method in a static context but for some reason I couldn't make `m_implementation` static. If you want to feel free to experiment with it.

Only managed to get rid of one `Tvheadend.h` include though, `Settings` still requires the `XBMC` pointer so we can't remove it yet (it could include `client.h` instead though).