### PR TITLE
Fix GetStatus 'lost connection' handling.

### DIFF
--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -208,6 +208,8 @@ public:
   inline bool IsConnected       ( void ) const { return m_ready; }
   bool        WaitForConnection ( void );
 
+  inline bool IsSuspended       ( void ) const { return m_suspended; }
+
   inline PLATFORM::CMutex& Mutex ( void ) { return m_mutex; }
 
   void        OnSleep ( void );
@@ -561,6 +563,10 @@ public:
   inline bool IsConnected ( void ) const
   {
     return m_conn.IsConnected();
+  }
+  inline bool IsSuspended ( void ) const
+  {
+    return m_conn.IsSuspended();
   }
   inline void OnSleep ( void )
   {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -120,8 +120,8 @@ ADDON_STATUS ADDON_GetStatus()
   CLockObject lock(g_mutex);
 
   // Check that we're still connected
-  if (m_CurStatus == ADDON_STATUS_OK && !tvh->IsConnected())
-    m_CurStatus = ADDON_STATUS_LOST_CONNECTION;
+  if (m_CurStatus == ADDON_STATUS_OK && !tvh->IsSuspended() && !tvh->IsConnected())
+    return ADDON_STATUS_LOST_CONNECTION;
 
   return m_CurStatus;
 }


### PR DESCRIPTION
This fixes addon function <code>ADDON_GetStatus</code> 

* to only return "connection lost" if not already suspended (would cause "connection lost" error toast while suspending and "connection restored" on wakeup, once https://github.com/ksooo/xbmc/tree/pvr-addon-connection-lost-handling is merged)
* to not overwrite m_CurStatus (same logic now as in function <code>ADDON_Create</code>)
* to return other status then "connection lost" after this state got set once, esp. after tvh actually reconnected. ;-)