### PR TITLE
Fix WIN32 build breaker (added missing include for std::min)

### DIFF
--- a/src/tvheadend/entity/Recording.h
+++ b/src/tvheadend/entity/Recording.h
@@ -21,6 +21,7 @@
  *
  */
 
+#include <algorithm>
 #include <map>
 #include <string>
 #include "kodi/xbmc_pvr_types.h"

--- a/src/tvheadend/entity/RecordingBase.cpp
+++ b/src/tvheadend/entity/RecordingBase.cpp
@@ -19,6 +19,8 @@
  *
  */
 
+#include <algorithm>
+
 #include "RecordingBase.h"
 
 using namespace tvheadend::entity;


### PR DESCRIPTION
Regression introduced by #125 :-(