### PR TITLE
Support for autorec/timerec update (new htsp v25 methods)

### DIFF
--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,5 +1,6 @@
 2.2.11
 - updated language files from Transifex
+- added: proper autorec/timerec support for HTSP v25 and above
 
 2.2.10
 - updated language files from Transifex

--- a/src/AutoRecordings.h
+++ b/src/AutoRecordings.h
@@ -59,6 +59,9 @@ public:
   bool ParseAutorecDelete(htsmsg_t *msg);
 
 private:
+  const std::string GetTimerStringIdFromIntId(int intId) const;
+  PVR_ERROR SendAutorecAddOrUpdate(const PVR_TIMER &timer, bool update);
+
   CHTSPConnection                      &m_conn;
   tvheadend::entity::AutoRecordingsMap  m_autoRecordings;
 };

--- a/src/TimeRecordings.h
+++ b/src/TimeRecordings.h
@@ -59,6 +59,9 @@ public:
   bool ParseTimerecDelete(htsmsg_t *msg);
 
 private:
+  const std::string GetTimerStringIdFromIntId(int intId) const;
+  PVR_ERROR SendTimerecAddOrUpdate(const PVR_TIMER &timer, bool update);
+
   CHTSPConnection                      &m_conn;
   tvheadend::entity::TimeRecordingsMap  m_timeRecordings;
 };

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -68,7 +68,7 @@ extern "C" {
  * Configuration defines
  */
 #define HTSP_MIN_SERVER_VERSION       (19) // Server must support at least this htsp version
-#define HTSP_CLIENT_VERSION           (24) // Client uses HTSP features up to this version. If the respective
+#define HTSP_CLIENT_VERSION           (25) // Client uses HTSP features up to this version. If the respective
                                            // addon feature requires htsp features introduced after
                                            // HTSP_MIN_SERVER_VERSION this feature will only be available if the
                                            // actual server HTSP version matches (runtime htsp version check).

--- a/src/tvheadend/entity/Recording.h
+++ b/src/tvheadend/entity/Recording.h
@@ -61,8 +61,7 @@ namespace tvheadend
         m_startExtra(0),
         m_stopExtra(0),
         m_state(PVR_TIMER_STATE_ERROR),
-        m_retention(99), // Kodi default - "99 days"
-        m_removal(-1),   // max value to stay compatible with older backends
+        m_lifetime(0),
         m_priority(50)   // Kodi default - "normal"
       {
       }
@@ -84,8 +83,7 @@ namespace tvheadend
                m_autorecId == other.m_autorecId &&
                m_state == other.m_state &&
                m_error == other.m_error &&
-               m_retention == other.m_retention &&
-               m_removal == other.m_removal &&
+               m_lifetime == other.m_lifetime &&
                m_priority == other.m_priority;
       }
 
@@ -174,9 +172,8 @@ namespace tvheadend
       void SetError(const std::string &error) { m_error = error; }
 
       // Lifetime = the smallest value
-      uint32_t GetLifetime() const { return std::min(m_removal, m_retention); }
-      void SetRetention(uint32_t retention) { m_retention = retention; }
-      void SetRemoval(uint32_t removal) { m_removal = removal; }
+      uint32_t GetLifetime() const { return m_lifetime; }
+      void SetLifetime(uint32_t lifetime) { m_lifetime = lifetime; }
 
       uint32_t GetPriority() const { return m_priority; }
       void SetPriority(uint32_t priority) { m_priority = priority; }
@@ -197,8 +194,7 @@ namespace tvheadend
       std::string      m_autorecId;
       PVR_TIMER_STATE  m_state;
       std::string      m_error;
-      uint32_t         m_retention;
-      uint32_t         m_removal;
+      uint32_t         m_lifetime;
       uint32_t         m_priority;
     };
   }

--- a/src/tvheadend/entity/RecordingBase.cpp
+++ b/src/tvheadend/entity/RecordingBase.cpp
@@ -29,8 +29,7 @@ RecordingBase::RecordingBase(const std::string &id /*= ""*/) :
     m_sid(id),
     m_enabled(0),
     m_daysOfWeek(0),
-    m_retention(0),
-    m_removal(-1), // max value to stay compatible with older backends
+    m_lifetime(0),
     m_priority(0),
     m_channel(0)
 {
@@ -42,8 +41,7 @@ bool RecordingBase::operator==(const RecordingBase &right)
   return m_id          == right.m_id          &&
          m_enabled     == right.m_enabled     &&
          m_daysOfWeek  == right.m_daysOfWeek  &&
-         m_retention   == right.m_retention   &&
-         m_removal     == right.m_removal     &&
+         m_lifetime    == right.m_lifetime    &&
          m_priority    == right.m_priority    &&
          m_title       == right.m_title       &&
          m_name        == right.m_name        &&
@@ -88,20 +86,14 @@ void RecordingBase::SetDaysOfWeek(uint32_t daysOfWeek)
   m_daysOfWeek = daysOfWeek;
 }
 
-// Lifetime = the smallest value
 uint32_t RecordingBase::GetLifetime() const
 {
-  return std::min(m_removal, m_retention);
+  return m_lifetime;
 }
 
-void RecordingBase::SetRetention(uint32_t retention)
+void RecordingBase::SetLifetime(uint32_t lifetime)
 {
-  m_retention = retention;
-}
-
-void RecordingBase::SetRemoval(uint32_t removal)
-{
-  m_removal = removal;
+  m_lifetime = lifetime;
 }
 
 uint32_t RecordingBase::GetPriority() const

--- a/src/tvheadend/entity/RecordingBase.h
+++ b/src/tvheadend/entity/RecordingBase.h
@@ -48,8 +48,7 @@ namespace tvheadend
       void SetDaysOfWeek(uint32_t daysOfWeek);
 
       uint32_t GetLifetime() const;
-      void SetRetention(uint32_t retention);
-      void SetRemoval(uint32_t removal);
+      void SetLifetime(uint32_t retention);
 
       uint32_t GetPriority() const;
       void SetPriority(uint32_t priority);
@@ -78,8 +77,7 @@ namespace tvheadend
       std::string m_sid;        // ID (string!) of dvr[Time|Auto]recEntry.
       uint32_t m_enabled;       // If [time|auto]rec entry is enabled (activated).
       uint32_t m_daysOfWeek;    // Bitmask - Days of week (0x01 = Monday, 0x40 = Sunday, 0x7f = Whole Week, 0 = Not set).
-      uint32_t m_retention;     // Lifetime time of database entry (in days).
-      uint32_t m_removal;       // Lifetime time of actual file on disk (in days).
+      uint32_t m_lifetime;      // Lifetime (in days).
       uint32_t m_priority;      // Priority (0 = Important, 1 = High, 2 = Normal, 3 = Low, 4 = Unimportant).
       std::string m_title;      // Title (pattern) for the recording files.
       std::string m_name;       // Name.


### PR DESCRIPTION
Since htsp v25 it's possible to do proper autorec/timerc update, so let's use it.
Unfortunately, the retention field was also changed.
https://github.com/tvheadend/tvheadend/blob/master/src/htsp_server.c#L981

So I think the best thing we can do is using "retention" for htsp < 25 en "removal" for newer versions. 
Removal is the main lifetime setting in recent tvh master builds, "retention" is set on "remove when file removed" 