### PR TITLE
Don't allow a pre or post recording time from 0 minutes.

### DIFF
--- a/src/AutoRecordings.cpp
+++ b/src/AutoRecordings.cpp
@@ -154,8 +154,8 @@ PVR_ERROR AutoRecordings::SendAutorecAdd(const PVR_TIMER &timer)
   if (m_conn.GetProtocol() >= 20)
     htsmsg_add_u32(m, "fulltext",   timer.bFullTextEpgSearch ? 1 : 0);
 
-  htsmsg_add_s64(m, "startExtra", timer.iMarginStart);
-  htsmsg_add_s64(m, "stopExtra",  timer.iMarginEnd);
+  htsmsg_add_s64(m, "startExtra", timer.iMarginStart > 0 ? timer.iMarginStart : 1); // 0 not supported by tvheadend
+  htsmsg_add_s64(m, "stopExtra",  timer.iMarginEnd   > 0 ? timer.iMarginEnd   : 1); // 0 not supported by tvheadend
   htsmsg_add_u32(m, "retention",  timer.iLifetime); // remove from tvh database
 
   if (m_conn.GetProtocol() >= 24)

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1115,8 +1115,8 @@ PVR_ERROR CTvheadend::UpdateTimer ( const PVR_TIMER &timer )
     htsmsg_add_s64(m, "start",        start);
     htsmsg_add_s64(m, "stop",         timer.endTime);
     htsmsg_add_str(m, "description",  timer.strSummary);
-    htsmsg_add_s64(m, "startExtra",   timer.iMarginStart);
-    htsmsg_add_s64(m, "stopExtra",    timer.iMarginEnd);
+    htsmsg_add_s64(m, "startExtra",   timer.iMarginStart > 0 ? timer.iMarginStart : 1); // 0 not supported by tvheadend
+    htsmsg_add_s64(m, "stopExtra",    timer.iMarginEnd   > 0 ? timer.iMarginEnd   : 1); // 0 not supported by tvheadend
     htsmsg_add_u32(m, "retention",    timer.iLifetime); // remove from tvh database
 
     if (m_conn.GetProtocol() >= 24)


### PR DESCRIPTION
This is not supported by tvheadend.
When setting this time to "0", the default pre/post recording time from the dvr config will be used.

Test scenario:
1) ensure that the default pre and post recording values for your dvr config are > 0 in tvheadend
2) add an autorec or epg based timer with pre and post record set to "0" in kodi
3) Open the timer settings in kodi after creation, you will see the values from step 1 now...

The best thing we can do is making this error as small as possible, so a pre/post time of "0" will be set to "1".