### PR TITLE
Fix cancel recording for timers created by autorec or timerec.

### DIFF
--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -6,6 +6,7 @@
 - improved: separate timer and streaming settings
 - added: default setting for timer lifetime, priority and duplicate detection
 - fixed: restart subscription after a connection restore
+- fixed: allow to abort active recordings also for timers created by timerec and autorec
 
 2.2.9
 - refactored the code by factoring out lots of things into separate files

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1060,6 +1060,22 @@ PVR_ERROR CTvheadend::DeleteTimer
     /* EPG-query-based repeating timer */
     return m_autoRecordings.SendAutorecDelete(timer);
   }
+  else if ((timer.iTimerType == TIMER_ONCE_CREATED_BY_TIMEREC) ||
+           (timer.iTimerType == TIMER_ONCE_CREATED_BY_AUTOREC))
+  {
+    /* Read-only timer created by autorec or timerec */
+    const auto &it = m_recordings.find(timer.iClientIndex);
+    if (it != m_recordings.end() && it->second.IsRecording())
+    {
+      /* This is actually a request to cancel an active recording. */
+      return SendDvrDelete(timer.iClientIndex, "cancelDvrEntry");
+    }
+    else
+    {
+      tvherror("timer is read-only");
+      return PVR_ERROR_INVALID_PARAMETERS;
+    }
+  }
   else
   {
     /* unknown timer */


### PR DESCRIPTION
pvr.hts part of the fix for case 2 of issue #150