### PR TITLE
Add intial build instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)
 
-# Tvheadend HTSP PVR
-Tvheadend HTSP PVR client addon for [Kodi] (http://kodi.tv)
+# Tvheadend PVR addon for Kodi
+
+This is a [Kodi] (http://kodi.tv) PVR addon for connecting to a [tvheadend](https://tvheadend.org) backend.
+
+## Build instructions
+
+### Linux
+
+1. `git clone https://github.com/xbmc/xbmc.git`
+2. `git clone https://github.com/kodi-pvr/pvr.hts.git`
+3. `cd pvr.hts && mkdir build && cd build`
+4. `cmake -DADDONS_TO_BUILD=pvr.hts -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/project/cmake/addons`
+5. `make`
+
+The addon files will be placed in `../../xbmc/addons` so if you build Kodi from source and run it directly 
+the addon will be available as a system addon.
 
 ##### Useful links
 


### PR DESCRIPTION
This way people don't have to go hunting down the forums. I'll try to add Windows instructions as well.

@adamsutton can you try this?