### PR TITLE
Factor out non-connection related stuff from CHTSPConnection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set(HTS_SOURCES_TVHEADEND_ENTITY
                 src/tvheadend/entity/TimeRecording.cpp)
 
 set(HTS_SOURCES_TVHEADEND_HTSP
+                src/tvheadend/htsp/Event.h
                 src/tvheadend/htsp/Response.h
                 src/tvheadend/htsp/Response.cpp
                 src/tvheadend/htsp/ServerInformation.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,10 @@ set(HTS_SOURCES_TVHEADEND_ENTITY
                 src/tvheadend/entity/TimeRecording.h
                 src/tvheadend/entity/TimeRecording.cpp)
 
+set(HTS_SOURCES_TVHEADEND_HTSP
+                src/tvheadend/htsp/ServerInformation.h
+                src/tvheadend/htsp/ServerInformation.cpp)
+
 set(HTS_SOURCES_TVHEADEND_STATUS
                 src/tvheadend/status/Quality.h
                 src/tvheadend/status/QueueStatus.h
@@ -71,6 +75,7 @@ set(HTS_SOURCES_TVHEADEND_UTILITIES
 source_group("Source Files" FILES ${HTS_SOURCES})
 source_group("Source Files\\tvheadend" FILES ${HTS_SOURCES_TVHEADEND})
 source_group("Source Files\\tvheadend\\entity" FILES ${HTS_SOURCES_TVHEADEND_ENTITY})
+source_group("Source Files\\tvheadend\\htsp" FILES ${HTS_SOURCES_TVHEADEND_HTSP})
 source_group("Source Files\\tvheadend\\status" FILES ${HTS_SOURCES_TVHEADEND_STATUS})
 source_group("Source Files\\tvheadend\\utilities" FILES ${HTS_SOURCES_TVHEADEND_UTILITIES})
 
@@ -89,6 +94,7 @@ source_group("Resource Files" FILES ${HTS_RESOURCES})
 list(APPEND HTS_SOURCES
             ${HTS_SOURCES_TVHEADEND}
             ${HTS_SOURCES_TVHEADEND_ENTITY}
+            ${HTS_SOURCES_TVHEADEND_HTSP}
             ${HTS_SOURCES_TVHEADEND_STATUS}
             ${HTS_SOURCES_TVHEADEND_UTILITIES}
             ${HTS_RESOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,9 @@ set(HTS_SOURCES_TVHEADEND_UTILITIES
                 src/tvheadend/utilities/Logger.h
                 src/tvheadend/utilities/Logger.cpp
                 src/tvheadend/utilities/AsyncState.cpp
-                src/tvheadend/utilities/AsyncState.h)
+                src/tvheadend/utilities/AsyncState.h
+                src/tvheadend/utilities/UrlHelper.h
+                src/tvheadend/utilities/UrlHelper.cpp)
                 
 source_group("Source Files" FILES ${HTS_SOURCES})
 source_group("Source Files\\tvheadend" FILES ${HTS_SOURCES_TVHEADEND})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@ set(HTS_SOURCES_TVHEADEND_ENTITY
                 src/tvheadend/entity/TimeRecording.cpp)
 
 set(HTS_SOURCES_TVHEADEND_HTSP
+                src/tvheadend/htsp/Response.h
+                src/tvheadend/htsp/Response.cpp
                 src/tvheadend/htsp/ServerInformation.h
                 src/tvheadend/htsp/ServerInformation.cpp)
 

--- a/src/HTSPConnection.cpp
+++ b/src/HTSPConnection.cpp
@@ -74,32 +74,6 @@ CHTSPConnection::~CHTSPConnection()
   StopThread(0);
 }
 
-/*
- * Info
- */
-
-std::string CHTSPConnection::GetWebURL ( const char *fmt, ... )
-{
-  va_list va;
-  const Settings &settings = Settings::GetInstance();
-
-  // Generate the authentication string (user:pass@)
-  std::string auth = settings.GetUsername();
-  if (!(auth.empty() || settings.GetPassword().empty()))
-    auth += ":" + settings.GetPassword();
-  if (!auth.empty())
-    auth += "@";
-
-  std::string url = StringUtils::Format("http://%s%s:%d", auth.c_str(), settings.GetHostname().c_str(), settings.GetPortHTTP());
-
-  va_start(va, fmt);
-  url += m_serverInformation.GetWebRoot();
-  url += StringUtils::FormatV(fmt, va);
-  va_end(va);
-
-  return url;
-}
-
 bool CHTSPConnection::WaitForConnection ( void )
 {
   if (!m_ready) {

--- a/src/HTSPConnection.cpp
+++ b/src/HTSPConnection.cpp
@@ -109,11 +109,6 @@ bool CHTSPConnection::WaitForConnection ( void )
   return m_ready;
 }
 
-bool CHTSPConnection::HasCapability(const std::string &capability) const
-{
-  return m_serverInformation.HasCapability(capability);
-}
-
 void CHTSPConnection::OnSleep ( void )
 {
   CLockObject lock(m_mutex);

--- a/src/HTSPConnection.cpp
+++ b/src/HTSPConnection.cpp
@@ -35,37 +35,8 @@ using namespace std;
 using namespace ADDON;
 using namespace P8PLATFORM;
 using namespace tvheadend;
+using namespace tvheadend::htsp;
 using namespace tvheadend::utilities;
-
-/*
- * HTSP Response objct
- */
-CHTSPResponse::CHTSPResponse ()
-  : m_flag(false), m_msg(NULL)
-{
-}
-
-CHTSPResponse::~CHTSPResponse ()
-{
-  if (m_msg) htsmsg_destroy(m_msg);
-  Set(NULL); // ensure signal is sent
-}
-
-void CHTSPResponse::Set ( htsmsg_t *msg )
-{
-  m_msg  = msg;
-  m_flag = true;
-  m_cond.Broadcast();
-}
-
-htsmsg_t *CHTSPResponse::Get ( CMutex &mutex, uint32_t timeout )
-{
-  m_cond.Wait(mutex, m_flag, timeout);
-  htsmsg_t *r = m_msg;
-  m_msg       = NULL;
-  m_flag      = false;
-  return r;
-}
 
 /*
  * Registration thread
@@ -251,8 +222,10 @@ bool CHTSPConnection::ReadMessage ( void )
   {
     Logger::Log(LogLevel::LEVEL_TRACE, "received response [%d]", seq);
     CLockObject lock(m_mutex);
-    CHTSPResponseList::iterator it;
-    if ((it = m_messages.find(seq)) != m_messages.end())
+
+    auto it = m_messages.find(seq);
+
+    if (it != m_messages.end())
     {
       it->second->Set(msg);
       return true;
@@ -329,7 +302,7 @@ htsmsg_t *CHTSPConnection::SendAndWait0 ( const char *method, htsmsg_t *msg, int
   uint32_t seq;
 
   /* Add Sequence number */
-  CHTSPResponse resp;
+  Response resp;
   seq = ++m_seq;
   htsmsg_add_u32(msg, "seq", seq);
   m_messages[seq] = &resp;

--- a/src/HTSPConnection.cpp
+++ b/src/HTSPConnection.cpp
@@ -121,7 +121,6 @@ std::string CHTSPConnection::GetWebURL ( const char *fmt, ... )
 
   std::string url = StringUtils::Format("http://%s%s:%d", auth.c_str(), settings.GetHostname().c_str(), settings.GetPortHTTP());
 
-  CLockObject lock(m_mutex);
   va_start(va, fmt);
   url += m_serverInformation.GetWebRoot();
   url += StringUtils::FormatV(fmt, va);
@@ -141,14 +140,11 @@ bool CHTSPConnection::WaitForConnection ( void )
 
 std::string CHTSPConnection::GetServerName ( void )
 {
-  CLockObject lock(m_mutex);
   return m_serverInformation.GetServerName();
 }
 
 std::string CHTSPConnection::GetServerVersion ( void )
 {
-  CLockObject lock(m_mutex);
-
   std::string serverVersion = m_serverInformation.GetServerVersion();
   uint32_t htspVersion = m_serverInformation.GetHtspVersion();
   return StringUtils::Format("%s (HTSP v%d)", serverVersion.c_str(), htspVersion);

--- a/src/HTSPConnection.cpp
+++ b/src/HTSPConnection.cpp
@@ -109,27 +109,6 @@ bool CHTSPConnection::WaitForConnection ( void )
   return m_ready;
 }
 
-std::string CHTSPConnection::GetServerName ( void )
-{
-  return m_serverInformation.GetServerName();
-}
-
-std::string CHTSPConnection::GetServerVersion ( void )
-{
-  std::string serverVersion = m_serverInformation.GetServerVersion();
-  uint32_t htspVersion = m_serverInformation.GetHtspVersion();
-  return StringUtils::Format("%s (HTSP v%d)", serverVersion.c_str(), htspVersion);
-}
-
-std::string CHTSPConnection::GetServerString ( void )
-{
-  const Settings &settings = Settings::GetInstance();
-
-  CLockObject lock(m_mutex);
-  return StringUtils::Format("%s:%d [%s]", settings.GetHostname().c_str(), settings.GetPortHTSP(),
-             m_ready ? "connected" : "disconnected");
-}
-
 bool CHTSPConnection::HasCapability(const std::string &capability) const
 {
   return m_serverInformation.HasCapability(capability);

--- a/src/HTSPTypes.h
+++ b/src/HTSPTypes.h
@@ -78,35 +78,3 @@ typedef enum {
   DVR_RET_SPACE     = INT32_MAX-1,  // the server may delete this recording if space for a new recording is needed (removal only)
   DVR_RET_FOREVER   = INT32_MAX     // the server should never delete this recording or database entry, only the user can do this
 } dvr_retention_t;
-
-enum eHTSPEventType
-{
-  HTSP_EVENT_CHN_UPDATE,
-  HTSP_EVENT_TAG_UPDATE,
-  HTSP_EVENT_EPG_UPDATE,
-  HTSP_EVENT_REC_UPDATE,
-};
-
-struct SHTSPEvent
-{
-  eHTSPEventType m_type;
-  uint32_t       m_idx;
-
-  SHTSPEvent (eHTSPEventType type, uint32_t idx = 0) :
-    m_type(type),
-    m_idx (idx)
-  {
-  }
-  
-  bool operator==(const SHTSPEvent &right) const
-  {
-    return m_type == right.m_type && m_idx == right.m_idx;
-  }
-
-  bool operator!=(const SHTSPEvent &right) const
-  {
-    return !(*this == right);
-  }
-};
-
-typedef std::vector<SHTSPEvent> SHTSPEventList;

--- a/src/HTSPTypes.h
+++ b/src/HTSPTypes.h
@@ -81,11 +81,10 @@ typedef enum {
 
 enum eHTSPEventType
 {
-  HTSP_EVENT_NONE = 0,
-  HTSP_EVENT_CHN_UPDATE = 1,
-  HTSP_EVENT_TAG_UPDATE = 2,
-  HTSP_EVENT_EPG_UPDATE = 3,
-  HTSP_EVENT_REC_UPDATE = 4,
+  HTSP_EVENT_CHN_UPDATE,
+  HTSP_EVENT_TAG_UPDATE,
+  HTSP_EVENT_EPG_UPDATE,
+  HTSP_EVENT_REC_UPDATE,
 };
 
 struct SHTSPEvent
@@ -93,7 +92,7 @@ struct SHTSPEvent
   eHTSPEventType m_type;
   uint32_t       m_idx;
 
-  SHTSPEvent (eHTSPEventType type = HTSP_EVENT_NONE, uint32_t idx = 0) :
+  SHTSPEvent (eHTSPEventType type, uint32_t idx = 0) :
     m_type(type),
     m_idx (idx)
   {

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1497,28 +1497,32 @@ void* CTvheadend::Process ( void )
 
 void CTvheadend::TriggerChannelGroupsUpdate()
 {
-  m_events.push_back(htsp::Event(htsp::EventType::TAG_UPDATE));
+  QueueEvent(htsp::Event(htsp::EventType::TAG_UPDATE));
 }
 
 void CTvheadend::TriggerChannelUpdate()
 {
-  m_events.push_back(htsp::Event(htsp::EventType::CHN_UPDATE));
+  QueueEvent(htsp::Event(htsp::EventType::CHN_UPDATE));
 }
 
 void CTvheadend::TriggerRecordingUpdate()
 {
-  m_events.push_back(htsp::Event(htsp::EventType::REC_UPDATE));
+  QueueEvent(htsp::Event(htsp::EventType::REC_UPDATE));
 }
 
 void CTvheadend::TriggerTimerUpdate()
 {
-  m_events.push_back(htsp::Event(htsp::EventType::REC_UPDATE));
+  QueueEvent(htsp::Event(htsp::EventType::REC_UPDATE));
 }
 
 void CTvheadend::TriggerEpgUpdate(uint32_t idx)
 {
-  auto event = htsp::Event(htsp::EventType::EPG_UPDATE, idx);
+  QueueEvent(htsp::Event(htsp::EventType::EPG_UPDATE, idx));
+}
 
+void CTvheadend::QueueEvent(const tvheadend::htsp::Event &event)
+{
+  /* Avoid queuing duplicate events */
   if (std::find(m_events.begin(), m_events.end(), event) == m_events.end())
     m_events.push_back(event);
 }

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -111,6 +111,23 @@ std::string CTvheadend::GetImageURL ( const char *str )
   }
 }
 
+std::string CTvheadend::GetServerName() const
+{
+  return m_conn.GetServerInformation().GetServerName();
+}
+
+std::string CTvheadend::GetServerVersion() const
+{
+  return m_conn.GetServerInformation().GetServerVersion();
+}
+
+std::string CTvheadend::GetServerString() const
+{
+  const Settings &settings = Settings::GetInstance();
+
+  return StringUtils::Format("%s:%d", settings.GetHostname().c_str(), settings.GetPortHTSP());
+}
+
 void CTvheadend::QueryAvailableProfiles()
 {
   /* Build message */

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1509,8 +1509,6 @@ void* CTvheadend::Process ( void )
         case HTSP_EVENT_EPG_UPDATE:
           PVR->TriggerEpgUpdate(it->m_idx);
           break;
-        case HTSP_EVENT_NONE:
-          break;
       }
     }
   }

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -28,6 +28,7 @@
 #include "Tvheadend.h"
 #include "tvheadend/utilities/Utilities.h"
 #include "tvheadend/utilities/Logger.h"
+#include "tvheadend/utilities/UrlHelper.h"
 
 using namespace std;
 using namespace ADDON;
@@ -94,21 +95,6 @@ error:
   htsmsg_destroy(m);
   Logger::Log(LogLevel::LEVEL_ERROR, "malformed getDiskSpace response: 'totaldiskspace'/'freediskspace' missing");
   return PVR_ERROR_SERVER_ERROR;
-}
-
-std::string CTvheadend::GetImageURL ( const char *str )
-{
-  if (*str != '/')
-  {
-    if (strncmp(str, "imagecache/", 11) == 0)
-      return m_conn.GetWebURL("/%s", str);
-
-    return str;
-  }
-  else
-  {
-    return m_conn.GetWebURL("%s", str);
-  }
 }
 
 std::string CTvheadend::GetServerName() const
@@ -1674,7 +1660,10 @@ void CTvheadend::ParseTagAddOrUpdate ( htsmsg_t *msg, bool bAdd )
 
   /* Icon */
   if ((str = htsmsg_get_str(msg, "tagIcon")) != NULL)
-    tag.SetIcon(GetImageURL(str));
+  {
+    UrlHelper urlHelper(Settings::GetInstance(), m_conn.GetServerInformation());
+    tag.SetIcon(urlHelper.GetImageUrl(str));
+  }
 
   /* Members */
   if ((list = htsmsg_get_list(msg, "members")) != NULL)
@@ -1765,7 +1754,10 @@ void CTvheadend::ParseChannelAddOrUpdate ( htsmsg_t *msg, bool bAdd )
 
   /* Channel icon */
   if ((str = htsmsg_get_str(msg, "channelIcon")) != NULL)
-    channel.SetIcon(GetImageURL(str));
+  {
+    UrlHelper urlHelper(Settings::GetInstance(), m_conn.GetServerInformation());
+    channel.SetIcon(urlHelper.GetImageUrl(str));
+  }
 
   /* Services */
   if ((list = htsmsg_get_list(msg, "services")) != NULL)

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -427,6 +427,7 @@ private:
   void TriggerRecordingUpdate();
   void TriggerTimerUpdate();
   void TriggerEpgUpdate(uint32_t idx);
+  void QueueEvent(const tvheadend::htsp::Event &event);
   void ProcessEvents(const tvheadend::htsp::EventList &events);
 
   /*

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -163,12 +163,9 @@ public:
   htsmsg_t *SendAndWait     ( const char *method, htsmsg_t *m, int iResponseTimeout = -1 );
 
   inline int  GetProtocol      ( void ) const { return m_serverInformation.GetHtspVersion(); }
+  const tvheadend::htsp::ServerInformation& GetServerInformation() const { return m_serverInformation; }
 
   std::string GetWebURL        ( const char *fmt, ... );
-
-  std::string GetServerName    ( void );
-  std::string GetServerVersion ( void );
-  std::string GetServerString  ( void );
   
   bool        HasCapability(const std::string &capability) const;
 
@@ -479,6 +476,11 @@ private:
   bool ParseEvent                ( htsmsg_t *msg, bool bAdd, tvheadend::entity::Event &evt );
 
 public:
+
+  std::string GetServerName() const;
+  std::string GetServerVersion() const;
+  std::string GetServerString() const;
+
   /*
    * Connection (pass-thru)
    */
@@ -486,18 +488,6 @@ public:
   {
     P8PLATFORM::CLockObject lock(m_conn.Mutex());
     return m_conn.WaitForConnection();
-  }
-  std::string GetServerName    ( void )
-  {
-    return m_conn.GetServerName();
-  }
-  std::string GetServerVersion ( void )
-  {
-    return m_conn.GetServerVersion();
-  }
-  std::string GetServerString  ( void )
-  {
-    return m_conn.GetServerString();
   }
   inline int GetProtocol ( void ) const
   {

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -166,8 +166,6 @@ public:
   const tvheadend::htsp::ServerInformation& GetServerInformation() const { return m_serverInformation; }
 
   std::string GetWebURL        ( const char *fmt, ... );
-  
-  bool        HasCapability(const std::string &capability) const;
 
   inline bool IsConnected       ( void ) const { return m_ready; }
   bool        WaitForConnection ( void );
@@ -495,7 +493,7 @@ public:
   }
   inline bool HasCapability(const std::string &capability) const
   {
-    return m_conn.HasCapability(capability);
+    return m_conn.GetServerInformation().HasCapability(capability);
   }
   inline bool IsConnected ( void ) const
   {

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -38,6 +38,7 @@
 #include "tvheadend/entity/Recording.h"
 #include "tvheadend/entity/Event.h"
 #include "tvheadend/entity/Schedule.h"
+#include "tvheadend/htsp/Event.h"
 #include "tvheadend/htsp/Response.h"
 #include "tvheadend/htsp/ServerInformation.h"
 #include "tvheadend/status/Quality.h"
@@ -397,7 +398,10 @@ private:
 
   tvheadend::ChannelTuningPredictor m_channelTuningPredictor;
 
-  SHTSPEventList              m_events;
+  /**
+   * List of pending events
+   */
+  tvheadend::htsp::EventList m_events;
 
   tvheadend::utilities::AsyncState  m_asyncState;
 
@@ -418,29 +422,12 @@ private:
   /*
    * Event handling
    */
-  inline void TriggerChannelGroupsUpdate ( void )
-  {
-    m_events.push_back(SHTSPEvent(HTSP_EVENT_TAG_UPDATE));
-  }
-  inline void TriggerChannelUpdate ( void )
-  {
-    m_events.push_back(SHTSPEvent(HTSP_EVENT_CHN_UPDATE));
-  }
-  inline void TriggerRecordingUpdate ( void )
-  {
-    m_events.push_back(SHTSPEvent(HTSP_EVENT_REC_UPDATE));
-  }
-  inline void TriggerTimerUpdate ( void )
-  {
-    m_events.push_back(SHTSPEvent(HTSP_EVENT_REC_UPDATE));
-  }
-  inline void TriggerEpgUpdate ( uint32_t idx )
-  {
-    SHTSPEvent event = SHTSPEvent(HTSP_EVENT_EPG_UPDATE, idx);
-    
-    if (std::find(m_events.begin(), m_events.end(), event) == m_events.end())
-      m_events.push_back(event);
-  }
+  void TriggerChannelGroupsUpdate();
+  void TriggerChannelUpdate();
+  void TriggerRecordingUpdate();
+  void TriggerTimerUpdate();
+  void TriggerEpgUpdate(uint32_t idx);
+  void ProcessEvents(const tvheadend::htsp::EventList &events);
 
   /*
    * Epg Handling

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -165,8 +165,6 @@ public:
   inline int  GetProtocol      ( void ) const { return m_serverInformation.GetHtspVersion(); }
   const tvheadend::htsp::ServerInformation& GetServerInformation() const { return m_serverInformation; }
 
-  std::string GetWebURL        ( const char *fmt, ... );
-
   inline bool IsConnected       ( void ) const { return m_ready; }
   bool        WaitForConnection ( void );
 
@@ -357,7 +355,6 @@ private:
   bool      CreateTimer       ( const tvheadend::entity::Recording &tvhTmr, PVR_TIMER &tmr );
 
   uint32_t GetNextUnnumberedChannelNumber ();
-  std::string GetImageURL     ( const char *str );
 
   /**
    * Queries the server for available streaming profiles and populates

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -38,6 +38,7 @@
 #include "tvheadend/entity/Recording.h"
 #include "tvheadend/entity/Event.h"
 #include "tvheadend/entity/Schedule.h"
+#include "tvheadend/htsp/Response.h"
 #include "tvheadend/htsp/ServerInformation.h"
 #include "tvheadend/status/Quality.h"
 #include "tvheadend/status/SourceInfo.h"
@@ -85,28 +86,10 @@ extern "C" {
 class CHTSPConnection;
 class CHTSPDemuxer;
 class CHTSPVFS;
-class CHTSPResponse;
 class CHTSPMessage;
 
 /* Typedefs */
-typedef std::map<uint32_t,CHTSPResponse*> CHTSPResponseList;
 typedef P8PLATFORM::SyncedBuffer<CHTSPMessage> CHTSPMessageQueue;
-
-/*
- * HTSP Response handler
- */
-class CHTSPResponse
-{
-public:
-  CHTSPResponse();
-  ~CHTSPResponse();
-  htsmsg_t *Get ( P8PLATFORM::CMutex &mutex, uint32_t timeout );
-  void      Set ( htsmsg_t *m );
-private:
-  P8PLATFORM::CCondition<volatile bool> m_cond;
-  bool                                m_flag;
-  htsmsg_t                           *m_msg;
-};
 
 /*
  * HTSP Message
@@ -216,7 +199,7 @@ private:
    */
   tvheadend::htsp::ServerInformation  m_serverInformation;
 
-  CHTSPResponseList                   m_messages;
+  tvheadend::htsp::ResponseList       m_messages;
 
   bool                                m_suspended;
 };

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -38,6 +38,7 @@
 #include "tvheadend/entity/Recording.h"
 #include "tvheadend/entity/Event.h"
 #include "tvheadend/entity/Schedule.h"
+#include "tvheadend/htsp/ServerInformation.h"
 #include "tvheadend/status/Quality.h"
 #include "tvheadend/status/SourceInfo.h"
 #include "tvheadend/status/TimeshiftStatus.h"
@@ -178,7 +179,7 @@ public:
   htsmsg_t *SendAndWait0    ( const char *method, htsmsg_t *m, int iResponseTimeout = -1);
   htsmsg_t *SendAndWait     ( const char *method, htsmsg_t *m, int iResponseTimeout = -1 );
 
-  inline int  GetProtocol      ( void ) const { return m_htspVersion; }
+  inline int  GetProtocol      ( void ) const { return m_serverInformation.GetHtspVersion(); }
 
   std::string GetWebURL        ( const char *fmt, ... );
 
@@ -209,15 +210,13 @@ private:
   P8PLATFORM::CCondition<volatile bool> m_regCond;
   bool                                m_ready;
   uint32_t                            m_seq;
-  std::string                         m_serverName;
-  std::string                         m_serverVersion;
-  int                                 m_htspVersion;
-  std::string                         m_webRoot;
-  void*                               m_challenge;
-  int                                 m_challengeLen;
+
+  /**
+   * The server information
+   */
+  tvheadend::htsp::ServerInformation  m_serverInformation;
 
   CHTSPResponseList                   m_messages;
-  std::vector<std::string>            m_capabilities;
 
   bool                                m_suspended;
 };

--- a/src/tvheadend/htsp/Event.h
+++ b/src/tvheadend/htsp/Event.h
@@ -1,0 +1,84 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2014 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <vector>
+#include <cstdint>
+
+namespace tvheadend
+{
+  namespace htsp
+  {
+
+    enum EventType
+    {
+      CHN_UPDATE,
+      TAG_UPDATE,
+      EPG_UPDATE,
+      REC_UPDATE,
+    };
+
+    class Event;
+    typedef std::vector<Event> EventList;
+
+    /**
+     * Represents an event that is a result of a HTSP message. An event requires
+     * Kodi to be triggered for an update (the type of update depending on the
+     * event type).
+     */
+    class Event
+    {
+
+    public:
+      Event(EventType type, uint32_t idx = 0)
+          : m_type(type), m_idx(idx)
+      {
+      }
+
+      bool operator==(const Event &right) const
+      {
+        return m_type == right.m_type && m_idx == right.m_idx;
+      }
+
+      bool operator!=(const Event &right) const
+      {
+        return !(*this == right);
+      }
+
+      EventType GetType() const
+      {
+        return m_type;
+      }
+
+      uint32_t GetIdx() const
+      {
+        return m_idx;
+      }
+
+    private:
+      EventType m_type;
+      uint32_t m_idx;
+
+    };
+
+  }
+}

--- a/src/tvheadend/htsp/Response.cpp
+++ b/src/tvheadend/htsp/Response.cpp
@@ -1,0 +1,53 @@
+/*
+ *      Copyright (C) 2005-2014 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "Response.h"
+
+using namespace tvheadend::htsp;
+
+Response::Response()
+    : m_flag(false), m_msg(NULL)
+{
+}
+
+Response::~Response()
+{
+  if (m_msg)
+    htsmsg_destroy(m_msg);
+
+  Set(nullptr); // ensure signal is sent
+}
+
+void Response::Set(htsmsg_t *msg)
+{
+  m_msg = msg;
+  m_flag = true;
+  m_cond.Broadcast();
+}
+
+htsmsg_t* Response::Get(P8PLATFORM::CMutex &mutex, uint32_t timeout)
+{
+  m_cond.Wait(mutex, m_flag, timeout);
+  htsmsg_t *r = m_msg;
+  m_msg = nullptr;
+  m_flag = false;
+  return r;
+}

--- a/src/tvheadend/htsp/Response.h
+++ b/src/tvheadend/htsp/Response.h
@@ -1,0 +1,61 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2014 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <map>
+#include "p8-platform/threads/mutex.h"
+
+extern "C" {
+#include <sys/types.h>
+#include "libhts/htsmsg.h"
+}
+
+namespace tvheadend
+{
+  namespace htsp
+  {
+
+    class Response;
+    typedef std::map<uint32_t, Response*> ResponseList;
+
+    /**
+     * Wrapper for HTSP responses. When a request is sent, a place holder
+     * in a ResponseList is created. When the response is received, the
+     * actual HTSP response is stored in the object using Set(). Get() is
+     * then used to retrieve the response.
+     */
+    class Response
+    {
+    public:
+      Response();
+      ~Response();
+
+      htsmsg_t *Get(P8PLATFORM::CMutex &mutex, uint32_t timeout);
+      void Set(htsmsg_t *m);
+
+    private:
+      P8PLATFORM::CCondition<volatile bool> m_cond;
+      bool m_flag;
+      htsmsg_t *m_msg;
+    };
+  }
+}

--- a/src/tvheadend/htsp/ServerInformation.cpp
+++ b/src/tvheadend/htsp/ServerInformation.cpp
@@ -35,63 +35,75 @@ ServerInformation::ServerInformation() :
 
 std::string ServerInformation::GetServerName() const
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
   return m_serverName;
 }
 
 void ServerInformation::SetServerName(const std::string &serverName)
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
   m_serverName = serverName;
 }
 
 std::string ServerInformation::GetServerVersion() const
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
   return StringUtils::Format("%s (HTSPv%d)",
                              m_serverVersion.c_str(), m_htspVersion);
 }
 
 void ServerInformation::SetServerVersion(const std::string &serverVersion)
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
   m_serverVersion = serverVersion;
 }
 
 uint32_t ServerInformation::GetHtspVersion() const
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
   return m_htspVersion;
 }
 
 void ServerInformation::SetHtspVersion(uint32_t htspVersion)
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
   m_htspVersion = htspVersion;
 }
 
 std::string ServerInformation::GetWebRoot() const
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
   return m_webRoot;
 }
 
 void ServerInformation::SetWebRoot(const std::string &webRoot)
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
   m_webRoot = webRoot;
 }
 
 bool ServerInformation::HasCapability(const std::string &capability) const
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
   return std::find(m_capabilities.begin(), m_capabilities.end(), capability)
          != m_capabilities.end();
 }
 
 void ServerInformation::AddCapability(const std::string &capability)
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
   m_capabilities.push_back(capability);
 }
 
 std::vector<uint8_t> ServerInformation::GetChallenge() const
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
   return m_challenge;
 }
 
 void ServerInformation::SetChallenge(const void *challenge, size_t challengeLen)
 {
+  std::lock_guard<std::mutex> lock(m_mutex);
   m_challenge.assign(reinterpret_cast<const uint8_t*>(challenge),
                      reinterpret_cast<const uint8_t*>(challenge) + challengeLen);
 }

--- a/src/tvheadend/htsp/ServerInformation.cpp
+++ b/src/tvheadend/htsp/ServerInformation.cpp
@@ -1,0 +1,97 @@
+/*
+ *      Copyright (C) 2005-2015 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "ServerInformation.h"
+#include "p8-platform/util/StringUtils.h"
+#include <algorithm>
+
+using namespace tvheadend::htsp;
+
+ServerInformation::ServerInformation() :
+    m_serverName(""),
+    m_serverVersion(""),
+    m_htspVersion(0),
+    m_webRoot("")
+{
+}
+
+std::string ServerInformation::GetServerName() const
+{
+  return m_serverName;
+}
+
+void ServerInformation::SetServerName(const std::string &serverName)
+{
+  m_serverName = serverName;
+}
+
+std::string ServerInformation::GetServerVersion() const
+{
+  return StringUtils::Format("%s (HTSPv%d)",
+                             m_serverVersion.c_str(), m_htspVersion);
+}
+
+void ServerInformation::SetServerVersion(const std::string &serverVersion)
+{
+  m_serverVersion = serverVersion;
+}
+
+uint32_t ServerInformation::GetHtspVersion() const
+{
+  return m_htspVersion;
+}
+
+void ServerInformation::SetHtspVersion(uint32_t htspVersion)
+{
+  m_htspVersion = htspVersion;
+}
+
+std::string ServerInformation::GetWebRoot() const
+{
+  return m_webRoot;
+}
+
+void ServerInformation::SetWebRoot(const std::string &webRoot)
+{
+  m_webRoot = webRoot;
+}
+
+bool ServerInformation::HasCapability(const std::string &capability) const
+{
+  return std::find(m_capabilities.begin(), m_capabilities.end(), capability)
+         != m_capabilities.end();
+}
+
+void ServerInformation::AddCapability(const std::string &capability)
+{
+  m_capabilities.push_back(capability);
+}
+
+std::vector<uint8_t> ServerInformation::GetChallenge() const
+{
+  return m_challenge;
+}
+
+void ServerInformation::SetChallenge(const void *challenge, size_t challengeLen)
+{
+  m_challenge.assign(reinterpret_cast<const uint8_t*>(challenge),
+                     reinterpret_cast<const uint8_t*>(challenge) + challengeLen);
+}

--- a/src/tvheadend/htsp/ServerInformation.h
+++ b/src/tvheadend/htsp/ServerInformation.h
@@ -1,0 +1,96 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2015 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <string>
+#include <vector>
+#include <cstdint>
+#include <cstdlib>
+
+namespace tvheadend
+{
+  namespace htsp
+  {
+
+    /**
+     * Holds information about a server (retrieved with the "hello" method)
+     */
+    class ServerInformation
+    {
+    public:
+
+      ServerInformation();
+
+      std::string GetServerName() const;
+      void SetServerName(const std::string &serverName);
+
+      std::string GetServerVersion() const;
+      void SetServerVersion(const std::string &serverVersion);
+
+      uint32_t GetHtspVersion() const;
+      void SetHtspVersion(uint32_t htspVersion);
+
+      std::string GetWebRoot() const;
+      void SetWebRoot(const std::string &webRoot);
+
+      bool HasCapability(const std::string &capability) const;
+      void AddCapability(const std::string &capability);
+
+      std::vector<uint8_t> GetChallenge() const;
+      void SetChallenge(const void *challenge, size_t challengeLen);
+
+    private:
+
+      /**
+       * The server name
+       */
+      std::string m_serverName;
+
+      /**
+       * The server version string
+       */
+      std::string m_serverVersion;
+
+      /**
+       * The HTSP version of the server
+       */
+      uint32_t m_htspVersion;
+
+      /**
+       * The web root for HTTP requests to the server
+       */
+      std::string m_webRoot;
+
+      /**
+       * The challenge (binary data) to use for authentication
+       */
+      std::vector<uint8_t> m_challenge;
+
+      /**
+       * The server capabilities
+       */
+      std::vector <std::string> m_capabilities;
+
+    };
+
+  }
+}

--- a/src/tvheadend/htsp/ServerInformation.h
+++ b/src/tvheadend/htsp/ServerInformation.h
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <vector>
+#include <mutex>
 #include <cstdint>
 #include <cstdlib>
 
@@ -32,7 +33,8 @@ namespace tvheadend
   {
 
     /**
-     * Holds information about a server (retrieved with the "hello" method)
+     * Holds information about a server (retrieved with the "hello" method).
+     * This class is thread-safe.
      */
     class ServerInformation
     {
@@ -89,6 +91,11 @@ namespace tvheadend
        * The server capabilities
        */
       std::vector <std::string> m_capabilities;
+
+      /**
+       * Protects access to member variables
+       */
+      mutable std::mutex m_mutex;
 
     };
 

--- a/src/tvheadend/utilities/UrlHelper.cpp
+++ b/src/tvheadend/utilities/UrlHelper.cpp
@@ -1,0 +1,63 @@
+/*
+ *      Copyright (C) 2005-2015 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "UrlHelper.h"
+#include "p8-platform/util/StringUtils.h"
+
+using namespace tvheadend;
+using namespace tvheadend::utilities;
+
+UrlHelper::UrlHelper(const tvheadend::Settings &settings,
+                     const tvheadend::htsp::ServerInformation &serverInformation)
+    : m_settings(settings),
+      m_serverInformation(serverInformation)
+{
+
+}
+
+std::string UrlHelper::GetImageUrl(const std::string &image) const
+{
+  // Image cache images
+  if (StringUtils::StartsWith(image, "imagecache/"))
+    return GetWebUrl("/" + image);
+
+  // Absolute or empty URLs
+  return image;
+}
+
+std::string UrlHelper::GetWebUrl(const std::string &resource) const
+{
+  return GetBaseUrl() + m_serverInformation.GetWebRoot() + resource;
+}
+
+std::string UrlHelper::GetBaseUrl() const
+{
+  // Generate the authentication string (user:pass@)
+  std::string auth = m_settings.GetUsername();
+
+  if (!(auth.empty() || m_settings.GetPassword().empty()))
+    auth += ":" + m_settings.GetPassword();
+  if (!auth.empty())
+    auth += "@";
+
+  return StringUtils::Format("http://%s%s:%d", auth.c_str(), m_settings.GetHostname().c_str(),
+                             m_settings.GetPortHTTP());
+}

--- a/src/tvheadend/utilities/UrlHelper.h
+++ b/src/tvheadend/utilities/UrlHelper.h
@@ -1,0 +1,68 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2015 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "../Settings.h"
+#include "../htsp/ServerInformation.h"
+#include <string>
+
+namespace tvheadend
+{
+  namespace utilities
+  {
+
+    /**
+     * Helper for generating URLs to resources on the server
+     */
+    class UrlHelper
+    {
+
+    public:
+      /**
+       * Constructor for injecting dependencies
+       */
+      UrlHelper(const tvheadend::Settings &settings,
+                const tvheadend::htsp::ServerInformation &serverInformation);
+
+      /**
+       * Returns the absolute URL to the specified image
+       */
+      std::string GetImageUrl(const std::string &image) const;
+
+    private:
+
+      /**
+       * Returns the absolute URL to the specified resource
+       */
+      std::string GetWebUrl(const std::string &resource) const;
+
+      /**
+       * Returns the base URL for all resources
+       */
+      std::string GetBaseUrl() const;
+
+      const tvheadend::Settings &m_settings;
+      const tvheadend::htsp::ServerInformation &m_serverInformation;
+
+    };
+  }
+}


### PR DESCRIPTION
Just another step in cleaning up our massive classes. I've moved out everything that's not directly related to performing "connection stuff" from `CHTSPConnection`. This includes:
- Move `CHTSPResponse` to separate files
- Holding server information in a separate instance of `ServerInformation`
- Create a simple URL helper for generating image URLs (`UrlHelper`)
