### PR TITLE
Fix crash when trace logging events 

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -105,7 +105,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* _unused(props))
     if (level == LogLevel::TRACE && !Settings::GetInstance().GetTraceDebug())
       return;
 
-    XBMC->Log(addonLevel, message);
+    XBMC->Log(addonLevel, "%s", message);
   });
 
   Logger::GetInstance().SetPrefix("pvr.hts");


### PR DESCRIPTION
Since we moved to the new logger utility everything will crash if a logged string contains a `%` character (because the list of expected variables increases and `vsprintf` tries to read too far).