### PR TITLE
Validate event before adding timer

### DIFF
--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -416,6 +416,14 @@ private:
   std::string GetStreamingProfile() const;
 
   /**
+   * Check if our event is valid
+   * @param eventId the event we want to check
+   * @param channelId the channel where the event belongs to
+   * @return true when valid, false otherwise
+   */
+  bool IsEventValid(uint32_t eventId, uint32_t channelId);
+
+  /**
    * The streaming profiles available on the server
    */
   tvheadend::Profiles         m_profiles;


### PR DESCRIPTION
This one is bothering me since ages.

Let me explain the problem first:
Sometimes when I add a epg based timer, pvr.hts return a server error.
The log files shows that tvheadend returned "Event does not exist"
I can resolve this problem by clearing the tv guide data and reload it.

Now the problem is that the epg handling in pvr.hts is synchronous by default.
So when an event gets updated/deleted/added on the backend, kodi will not be aware of this.
Kodi will refetch its epg data on intervals of minimum 15 minutes (user sets this in tv settings), for low power systems, kodi will not fetch any epg data when video is playing (by default)...

These problems will increase the risk that the kodi epg data isn't up to date anymore with the backend and this may result in  "Event does not exist".

The problem seems more common on now/next epg events, this is probably due to the fact that some providers do real time adjustments for them.

Possible solutions I found are:
1) switch epg to async by default (some major disadvantages)
2) fallback to a manual timer in case an event doesn't exists anymore

I implemented solution 2 in this PR, I know it's not perfect, but I can't come up with a better solutions.
If someone has a better idea, please let me know ;-)

@Jalle19 @ksooo 