### PR TITLE
Parse, store and log descrambler info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ source_group("Resource Files" FILES ${HTS_RESOURCES})
 list(APPEND HTS_SOURCES
             ${HTS_SOURCES_TVHEADEND}
             ${HTS_SOURCES_TVHEADEND_ENTITY}
+            ${HTS_SOURCES_TVHEADEND_STATUS}
             ${HTS_SOURCES_TVHEADEND_UTILITIES}
             ${HTS_RESOURCES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ set(HTS_SOURCES_TVHEADEND_ENTITY
                 src/tvheadend/entity/TimeRecording.cpp)
 
 set(HTS_SOURCES_TVHEADEND_STATUS
+                src/tvheadend/status/DescrambleInfo.h
+                src/tvheadend/status/DescrambleInfo.cpp
                 src/tvheadend/status/Quality.h
                 src/tvheadend/status/QueueStatus.h
                 src/tvheadend/status/SourceInfo.h

--- a/src/HTSPDemuxer.cpp
+++ b/src/HTSPDemuxer.cpp
@@ -250,6 +250,8 @@ bool CHTSPDemuxer::ProcessMessage ( const char *method, htsmsg_t *m )
     ParseSignalStatus(m);
   else if (!strcmp("timeshiftStatus", method))
     ParseTimeshiftStatus(m);
+  else if (!strcmp("descrambleInfo", method))
+    ParseDescrambleInfo(m);
   else if (!strcmp("subscriptionStart", method))
     ParseSubscriptionStart(m);
   else if (!strcmp("subscriptionStop", method))
@@ -617,4 +619,55 @@ void CHTSPDemuxer::ParseTimeshiftStatus ( htsmsg_t *m )
     Logger::Log(LogLevel::LEVEL_TRACE, "  end   : %lld", s64);
     m_timeshiftStatus.end = s64;
   }
+}
+
+void CHTSPDemuxer::ParseDescrambleInfo(htsmsg_t *m)
+{
+  uint32_t pid = 0, caid = 0, provid = 0, ecmtime = 0, hops = 0;
+  const char *cardsystem, *reader, *from, *protocol;
+
+  /* Parse mandatory fields */
+  if (htsmsg_get_u32(m, "pid", &pid) ||
+      htsmsg_get_u32(m, "caid", &caid) ||
+      htsmsg_get_u32(m, "provid", &provid) ||
+      htsmsg_get_u32(m, "ecmtime", &ecmtime) ||
+      htsmsg_get_u32(m, "hops", &hops))
+  {
+    Logger::Log(LogLevel::LEVEL_ERROR, "malformed descrambleInfo, mandatory parameters missing");
+    return;
+  }
+
+  /* Parse optional fields */
+  cardsystem = htsmsg_get_str(m, "cardsystem");
+  reader = htsmsg_get_str(m, "reader");
+  from = htsmsg_get_str(m, "from");
+  protocol = htsmsg_get_str(m, "protocol");
+
+  /* Store */
+  m_descrambleInfo.SetPid(pid);
+  m_descrambleInfo.SetCaid(caid);
+  m_descrambleInfo.SetProvid(provid);
+  m_descrambleInfo.SetEcmTime(ecmtime);
+  m_descrambleInfo.SetHops(hops);
+
+  if (cardsystem)
+    m_descrambleInfo.SetCardSystem(cardsystem);
+  if (reader)
+    m_descrambleInfo.SetReader(reader);
+  if (from)
+    m_descrambleInfo.SetFrom(from);
+  if (protocol)
+    m_descrambleInfo.SetProtocol(protocol);
+
+  /* Log */
+  Logger::Log(LogLevel::LEVEL_TRACE, "descrambleInfo:");
+  Logger::Log(LogLevel::LEVEL_TRACE, "  pid: %d", pid);
+  Logger::Log(LogLevel::LEVEL_TRACE, "  caid: 0x%X", caid);
+  Logger::Log(LogLevel::LEVEL_TRACE, "  provid: %d", provid);
+  Logger::Log(LogLevel::LEVEL_TRACE, "  ecmtime: %d", ecmtime);
+  Logger::Log(LogLevel::LEVEL_TRACE, "  hops: %d", hops);
+  Logger::Log(LogLevel::LEVEL_TRACE, "  cardsystem: %s", cardsystem);
+  Logger::Log(LogLevel::LEVEL_TRACE, "  reader: %s", reader);
+  Logger::Log(LogLevel::LEVEL_TRACE, "  from: %s", from);
+  Logger::Log(LogLevel::LEVEL_TRACE, "  protocol: %s", protocol);
 }

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -38,6 +38,7 @@
 #include "tvheadend/entity/Recording.h"
 #include "tvheadend/entity/Event.h"
 #include "tvheadend/entity/Schedule.h"
+#include "tvheadend/status/DescrambleInfo.h"
 #include "tvheadend/status/Quality.h"
 #include "tvheadend/status/SourceInfo.h"
 #include "tvheadend/status/TimeshiftStatus.h"
@@ -283,6 +284,7 @@ private:
   tvheadend::status::SourceInfo           m_sourceInfo;
   tvheadend::status::Quality              m_signalInfo;
   tvheadend::status::TimeshiftStatus      m_timeshiftStatus;
+  tvheadend::status::DescrambleInfo       m_descrambleInfo;
   tvheadend::Subscription                 m_subscription;
   time_t                                  m_lastUse;
   
@@ -310,6 +312,7 @@ private:
   void ParseQueueStatus         ( htsmsg_t *m );
   void ParseSignalStatus        ( htsmsg_t *m );
   void ParseTimeshiftStatus     ( htsmsg_t *m );
+  void ParseDescrambleInfo      ( htsmsg_t *m );
 };
 
 /*

--- a/src/tvheadend/status/DescrambleInfo.cpp
+++ b/src/tvheadend/status/DescrambleInfo.cpp
@@ -1,0 +1,114 @@
+/*
+ *      Copyright (C) 2005-2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "DescrambleInfo.h"
+
+using namespace tvheadend::status;
+
+uint32_t DescrambleInfo::GetPid() const
+{
+  return m_pid;
+}
+
+void DescrambleInfo::SetPid(uint32_t pid)
+{
+  m_pid = pid;
+}
+
+uint32_t DescrambleInfo::GetCaid() const
+{
+  return m_caid;
+}
+
+void DescrambleInfo::SetCaid(uint32_t caid)
+{
+  m_caid = caid;
+}
+
+uint32_t DescrambleInfo::GetProvid() const
+{
+  return m_provid;
+}
+
+void DescrambleInfo::SetProvid(uint32_t provid)
+{
+  m_provid = provid;
+}
+
+uint32_t DescrambleInfo::GetEcmTime() const
+{
+  return m_ecmTime;
+}
+
+void DescrambleInfo::SetEcmTime(uint32_t ecmTime)
+{
+  m_ecmTime = ecmTime;
+}
+
+uint32_t DescrambleInfo::GetHops() const
+{
+  return m_hops;
+}
+
+void DescrambleInfo::SetHops(uint32_t hops)
+{
+  m_hops = hops;
+}
+
+std::string DescrambleInfo::GetCardSystem() const
+{
+  return m_cardSystem;
+}
+
+void DescrambleInfo::SetCardSystem(const std::string &cardSystem)
+{
+  m_cardSystem = cardSystem;
+}
+
+std::string DescrambleInfo::GetReader() const
+{
+  return m_reader;
+}
+
+void DescrambleInfo::SetReader(const std::string &reader)
+{
+  m_reader = reader;
+}
+
+std::string DescrambleInfo::GetFrom() const
+{
+  return m_from;
+}
+
+void DescrambleInfo::SetFrom(const std::string &from)
+{
+  m_from = from;
+}
+
+std::string DescrambleInfo::GetProtocol() const
+{
+  return m_protocol;
+}
+
+void DescrambleInfo::SetProtocol(const std::string &protocol)
+{
+  m_protocol = protocol;
+}

--- a/src/tvheadend/status/DescrambleInfo.h
+++ b/src/tvheadend/status/DescrambleInfo.h
@@ -1,0 +1,80 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <cstdint>
+#include <string>
+
+namespace tvheadend
+{
+  namespace status
+  {
+
+    /**
+     * Contains information about the descrambler used
+     */
+    class DescrambleInfo
+    {
+    public:
+
+      uint32_t GetPid() const;
+      void SetPid(uint32_t pid);
+
+      uint32_t GetCaid() const;
+      void SetCaid(uint32_t caid);
+
+      uint32_t GetProvid() const;
+      void SetProvid(uint32_t provid);
+
+      uint32_t GetEcmTime() const;
+      void SetEcmTime(uint32_t ecmTime);
+
+      uint32_t GetHops() const;
+      void SetHops(uint32_t hops);
+
+      std::string GetCardSystem() const;
+      void SetCardSystem(const std::string &cardSystem);
+
+      std::string GetReader() const;
+      void SetReader(const std::string &reader);
+
+      std::string GetFrom() const;
+      void SetFrom(const std::string &from);
+
+      std::string GetProtocol() const;
+      void SetProtocol(const std::string &protocol);
+
+    private:
+      uint32_t m_pid;
+      uint32_t m_caid;
+      uint32_t m_provid;
+      uint32_t m_ecmTime;
+      uint32_t m_hops;
+      std::string m_cardSystem;
+      std::string m_reader;
+      std::string m_from;
+      std::string m_protocol;
+
+    };
+
+  }
+}

--- a/src/tvheadend/status/Quality.h
+++ b/src/tvheadend/status/Quality.h
@@ -21,6 +21,7 @@
  *
  */
 
+#include <cstdint>
 #include <string>
 
 namespace tvheadend

--- a/src/tvheadend/status/QueueStatus.h
+++ b/src/tvheadend/status/QueueStatus.h
@@ -21,6 +21,8 @@
  *
  */
 
+#include <cstdint>
+
 namespace tvheadend {
   namespace status {
     /**

--- a/src/tvheadend/status/TimeshiftStatus.h
+++ b/src/tvheadend/status/TimeshiftStatus.h
@@ -21,6 +21,8 @@
  *
  */
 
+#include <cstdint>
+
 namespace tvheadend
 {
   namespace status


### PR DESCRIPTION
Partially closes https://github.com/kodi-pvr/pvr.hts/issues/106. The API will need some changes in order to make this information useful (for now it's just stored, not passed along to Kodi in any way).
