### PR TITLE
Fix schedules dirty flag handling.

### DIFF
--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -2109,6 +2109,7 @@ void CTvheadend::ParseEventAddOrUpdate ( htsmsg_t *msg, bool bAdd )
   Event    &evt    = events[tmp.GetId()];
   Event comparison = evt;
   sched.SetId(tmp.GetChannel());
+  sched.SetDirty(false);
   evt.SetId(tmp.GetId());
   evt.SetDirty(false);
   

--- a/src/tvheadend/entity/Schedule.cpp
+++ b/src/tvheadend/entity/Schedule.cpp
@@ -27,9 +27,12 @@ void Schedule::SetDirty(bool dirty)
 {
   Entity::SetDirty(dirty);
 
-  // Mark all events as dirty too
-  for (auto &entry : m_events)
-    entry.second.SetDirty(dirty);
+  if (dirty)
+  {
+    // Mark all events as dirty too
+    for (auto &entry : m_events)
+      entry.second.SetDirty(dirty);
+  }
 }
 
 Segment Schedule::GetSegment(time_t startTime, time_t endTime) const


### PR DESCRIPTION
Stupid bug with async epg transfer.
 
After every reconnect to tvh backend (first connect after Kodi startup is not affected), <code>CTvheadend::Connected</code> sets all schedules and epg events to "dirty". => https://github.com/kodi-pvr/pvr.hts/blob/master/src/Tvheadend.cpp#L1341

Then, "enableAsyncMetaData" is send to tvh backend. Subsequent asyncronous epg event adds/updates reset the dirty flag for epg events, but not for the associated schedule. => https://github.com/kodi-pvr/pvr.hts/blob/master/src/Tvheadend.cpp#L2113

Result is, that after tvh backend sent "initialSyncCompleted", all(!) schedules are still "dirty" with the consequence, that the subsequently called <code>CTvheadend::SyncEpgCompleted</code> deletes all(!) schedules, including all(!) associated epg events here: https://github.com/kodi-pvr/pvr.hts/blob/master/src/Tvheadend.cpp#L1607.

This means, m_schedules is effectively empty after each reconnect + initial sync and will only be refilled (partly) by subsequent "eventAdded"/"eventUpdated" callbacks from tvh. Means also, that <code>CTvheadend::GetEpg</code> with async epg transfer activated, which pulls data only from m_schedules then, will not return the data that are actually availably in tvh backend.

As I usually do suspend/resume instead of shutting it down my Kodi box in the living room I'm affected by this bug every day...

@Jalle19 have not runtime-checked this (not at home currently). Cannot really believe what I just wrote, though... Do I have a brain fart or have we really overlooked this bug so far?