### PR TITLE
fix compiler warning: -Wsign-compare

### DIFF
--- a/src/AutoRecordings.cpp
+++ b/src/AutoRecordings.cpp
@@ -138,7 +138,7 @@ const unsigned int AutoRecordings::GetTimerIntIdFromStringId(const std::string &
   return 0;
 }
 
-const std::string AutoRecordings::GetTimerStringIdFromIntId(int intId) const
+const std::string AutoRecordings::GetTimerStringIdFromIntId(unsigned int intId) const
 {
   for (auto tit = m_autoRecordings.begin(); tit != m_autoRecordings.end(); ++tit)
   {

--- a/src/AutoRecordings.h
+++ b/src/AutoRecordings.h
@@ -59,7 +59,7 @@ public:
   bool ParseAutorecDelete(htsmsg_t *msg);
 
 private:
-  const std::string GetTimerStringIdFromIntId(int intId) const;
+  const std::string GetTimerStringIdFromIntId(unsigned int intId) const;
   PVR_ERROR SendAutorecAddOrUpdate(const PVR_TIMER &timer, bool update);
 
   CHTSPConnection                      &m_conn;

--- a/src/TimeRecordings.cpp
+++ b/src/TimeRecordings.cpp
@@ -113,7 +113,7 @@ const unsigned int TimeRecordings::GetTimerIntIdFromStringId(const std::string &
   return 0;
 }
 
-const std::string TimeRecordings::GetTimerStringIdFromIntId(int intId) const
+const std::string TimeRecordings::GetTimerStringIdFromIntId(unsigned int intId) const
 {
   for (auto tit = m_timeRecordings.begin(); tit != m_timeRecordings.end(); ++tit)
   {

--- a/src/TimeRecordings.h
+++ b/src/TimeRecordings.h
@@ -59,7 +59,7 @@ public:
   bool ParseTimerecDelete(htsmsg_t *msg);
 
 private:
-  const std::string GetTimerStringIdFromIntId(int intId) const;
+  const std::string GetTimerStringIdFromIntId(unsigned int intId) const;
   PVR_ERROR SendTimerecAddOrUpdate(const PVR_TIMER &timer, bool update);
 
   CHTSPConnection                      &m_conn;


### PR DESCRIPTION
/home/kai/src/openelec/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/pvr.hts-c4d79d8/src/TimeRecordings.cpp: In member function 'const string TimeRecordings::GetTimerStringIdFromIntId(int) const':
/home/kai/src/openelec/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/pvr.hts-c4d79d8/src/TimeRecordings.cpp:120:29: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (tit->second.GetId() == intId)
                             ^
/home/kai/src/openelec/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/pvr.hts-c4d79d8/src/AutoRecordings.cpp: In member function 'const string AutoRecordings::GetTimerStringIdFromIntId(int) const':
/home/kai/src/openelec/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/pvr.hts-c4d79d8/src/AutoRecordings.cpp:145:29: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (tit->second.GetId() == intId)

@Jalle19 okay?