### PR TITLE
Updated to PVR API v4.2.0 (implemented IsRealTimeStream)

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="3.0.1"
+  version="3.0.2"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="4.1.0"/>
+    <import addon="xbmc.pvr" version="4.2.0"/>
     <import addon="xbmc.codec" version="1.0.1"/>
   </requires>
   <extension

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+3.0.2
+- updated to PVR API v4.2.0 (implemented IsRealTimeStream)
+
 3.0.1
 - updated language files from Transifex
 

--- a/src/HTSPDemuxer.cpp
+++ b/src/HTSPDemuxer.cpp
@@ -231,6 +231,17 @@ void CHTSPDemuxer::SetStreamingProfile(const std::string &profile)
   m_subscription.SetProfile(profile);
 }
 
+bool CHTSPDemuxer::IsRealTimeStream() const
+{
+  if (GetTimeshiftTime() == 0)
+    return true;
+
+  if (GetTimeshiftBufferEnd() - GetTimeshiftTime() < 10)
+    return true;
+
+  return false;
+}
+
 /* **************************************************************************
  * Parse incoming data
  * *************************************************************************/

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -2352,3 +2352,9 @@ int64_t CTvheadend::DemuxGetTimeshiftBufferEnd() const
 {
   return m_dmx_active->GetTimeshiftBufferEnd();
 }
+
+bool CTvheadend::DemuxIsRealTimeStream() const
+{
+  return m_dmx_active->IsRealTimeStream();
+}
+

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -265,6 +265,7 @@ public:
       return m_lastUse;
     return 0;
   }
+  bool IsRealTimeStream() const;
 
   /**
    * Tells each demuxer to use the specified profile for new subscriptions
@@ -273,9 +274,9 @@ public:
   void SetStreamingProfile(const std::string &profile);
 
 private:
-  P8PLATFORM::CMutex                        m_mutex;
+  P8PLATFORM::CMutex                      m_mutex;
   CHTSPConnection                        &m_conn;
-  P8PLATFORM::SyncedBuffer<DemuxPacket*>    m_pktBuffer;
+  P8PLATFORM::SyncedBuffer<DemuxPacket*>  m_pktBuffer;
   ADDON::XbmcStreamProperties             m_streams;
   std::map<int,int>                       m_streamStat;
   int64_t                                 m_seekTime;
@@ -568,6 +569,7 @@ public:
   int64_t      DemuxGetTimeshiftTime() const;
   int64_t      DemuxGetTimeshiftBufferStart() const;
   int64_t      DemuxGetTimeshiftBufferEnd() const;
+  bool         DemuxIsRealTimeStream() const;
 
   /*
    * VFS (pass-thru)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -301,6 +301,33 @@ bool IsTimeshifting(void)
   return tvh->DemuxGetTimeshiftTime() != 0;
 }
 
+static time_t ConvertMusecsToTime(int64_t musecs)
+{
+  // tvheadend reports microseconds for timeshifting values,
+  // Kodi expects it to be an absolute UNIX timestamp
+  return time(NULL) - static_cast<time_t>(static_cast<double>(musecs / 1000000));
+}
+
+time_t GetPlayingTime()
+{
+  return ConvertMusecsToTime(tvh->DemuxGetTimeshiftTime());
+}
+
+time_t GetBufferTimeStart()
+{
+  return ConvertMusecsToTime(tvh->DemuxGetTimeshiftBufferStart());
+}
+
+time_t GetBufferTimeEnd()
+{
+  return ConvertMusecsToTime(tvh->DemuxGetTimeshiftBufferEnd());
+}
+
+bool IsRealTimeStream()
+{
+  return tvh->DemuxIsRealTimeStream();
+}
+
 bool OpenLiveStream(const PVR_CHANNEL &channel)
 {
   return tvh->DemuxOpen(channel);
@@ -554,26 +581,6 @@ PVR_ERROR OpenDialogChannelAdd(const PVR_CHANNEL &_unused(channel))
 /* Timeshift?? - not sure if we can use these? */
 void PauseStream(bool _unused(bPaused))
 {
-}
-
-static time_t ConvertMusecsToTime(int64_t musecs)
-{
-  // tvheadend reports microseconds for timeshifting values,
-  // Kodi expects it to be an absolute UNIX timestamp
-  return time(NULL) - static_cast<time_t>(static_cast<double>(musecs / 1000000));
-}
-
-time_t GetPlayingTime()
-{
-  return ConvertMusecsToTime(tvh->DemuxGetTimeshiftTime());
-}
-time_t GetBufferTimeStart()
-{
-  return ConvertMusecsToTime(tvh->DemuxGetTimeshiftBufferStart());
-}
-time_t GetBufferTimeEnd()
-{
-  return ConvertMusecsToTime(tvh->DemuxGetTimeshiftBufferEnd());
 }
 
 /* Live stream (VFS interface - not relevant) */


### PR DESCRIPTION
Implementation should basically do the same as pvr.vdr.vnsi: https://github.com/kodi-pvr/pvr.vdr.vnsi/commit/3b94c58114f93c42e38741fb1dd403858bfe04b2#diff-34f48ad91ac6c202ac60b0348ae90e30R862

@Jalle19 good to go?