### PR TITLE
compiler warning: fixed CHTSPDemuxer member init order

### DIFF
--- a/src/HTSPDemuxer.cpp
+++ b/src/HTSPDemuxer.cpp
@@ -34,9 +34,8 @@ using namespace tvheadend::utilities;
 CHTSPDemuxer::CHTSPDemuxer ( CHTSPConnection &conn )
   : m_conn(conn), m_pktBuffer((size_t)-1),
     m_seekTime(INVALID_SEEKTIME),
-    m_subscription(conn),
     m_seeking(false), m_speedChange(false),
-    m_lastUse(0)
+    m_subscription(conn), m_lastUse(0)
 {
 }
 


### PR DESCRIPTION
straight forward:

/home/kai/src/openelec/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/pvr.hts-28d3613/src/Tvheadend.h:267:27: warning: 'CHTSPDemuxer::m_subscription' will be initialized after [-Wreorder]
   tvheadend::Subscription                 m_subscription;
                           ^
/home/kai/src/openelec/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/pvr.hts-28d3613/src/Tvheadend.h:262:8: warning:   'bool CHTSPDemuxer::m_seeking' [-Wreorder]
   bool                                    m_seeking;
        ^
/home/kai/src/openelec/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/pvr.hts-28d3613/src/HTSPDemuxer.cpp:34:1: warning:   when initialized here [-Wreorder]
 CHTSPDemuxer::CHTSPDemuxer ( CHTSPConnection &conn )
 ^
