### PR TITLE
Remove superfluous "attempting reconnect" log message

### DIFF
--- a/src/HTSPConnection.cpp
+++ b/src/HTSPConnection.cpp
@@ -597,10 +597,7 @@ void* CHTSPConnection::Process ( void )
     while (!IsStopped())
     {
       if (!ReadMessage())
-      {
-        Logger::Log(LogLevel::LEVEL_DEBUG, "attempting reconnect");
         break;
-      }
     }
 
     /* Stop connect thread (if not already) */


### PR DESCRIPTION
It will be triggered during shutdown when it's obvious there will be no
reconnect attempt made.

@ksooo ?