### PR TITLE
Sanity check frames before triggering a stream change

### DIFF
--- a/src/HTSPDemuxer.cpp
+++ b/src/HTSPDemuxer.cpp
@@ -481,6 +481,9 @@ void CHTSPDemuxer::ParseSubscriptionStart ( htsmsg_t *m )
         
         if ((language = htsmsg_get_str(&f->hmf_msg, "language")) != NULL)
           strncpy(stream.strLanguage, language, sizeof(stream.strLanguage) - 1);
+
+        Logger::Log(LogLevel::LEVEL_DEBUG, "  id: %d, type %s, codec: %u, language: %s",
+                    idx, type, stream.iCodecId, stream.strLanguage);
       }
 
       /* Audio data */
@@ -515,10 +518,12 @@ void CHTSPDemuxer::ParseSubscriptionStart ( htsmsg_t *m )
           stream.iFPSScale = u32;
           stream.iFPSRate  = DVD_TIME_BASE;
         }
+
+        Logger::Log(LogLevel::LEVEL_DEBUG, "  id: %d, type %s, codec: %u, dimensions: %dx%d",
+                    idx, type, stream.iCodecId, stream.iWidth, stream.iHeight);
       }
         
       streams.push_back(stream);
-      Logger::Log(LogLevel::LEVEL_DEBUG, "  id: %d, type %s, codec: %u", idx, type, stream.iCodecId);
     }
   }
 

--- a/src/HTSPDemuxer.cpp
+++ b/src/HTSPDemuxer.cpp
@@ -431,6 +431,8 @@ void CHTSPDemuxer::ParseSubscriptionStart ( htsmsg_t *m )
     Logger::Log(LogLevel::LEVEL_ERROR, "malformed subscriptionStart: 'streams' missing");
     return;
   }
+
+  Logger::Log(LogLevel::LEVEL_DEBUG, "demux subscription start");
   m_streamStat.clear();
 
   /* Process each */
@@ -450,7 +452,6 @@ void CHTSPDemuxer::ParseSubscriptionStart ( htsmsg_t *m )
     /* Find stream */
     m_streamStat[idx] = 0;
     m_streams.GetStreamData(idx, &stream);
-    Logger::Log(LogLevel::LEVEL_DEBUG, "demux subscription start");
     
     CodecDescriptor codecDescriptor = CodecDescriptor::GetCodecByName(type);
     xbmc_codec_t codec = codecDescriptor.Codec();

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -265,6 +265,7 @@ private:
   tvheadend::status::TimeshiftStatus      m_timeshiftStatus;
   tvheadend::Subscription                 m_subscription;
   std::atomic<time_t>                     m_lastUse;
+  bool                                    m_gotIframe;
   
   void         Close0         ( void );
   void         Abort0         ( void );


### PR DESCRIPTION
Someone once told me that tvheadend makes sure that the first packet after a `subscriptionStart` message is guaranteed to be an I-frame. This is apparently not true (as can be seen with trace logging enabled).

Normally, that shouldn't be such as a big deal, but for some reason, ffmpeg can throw `[mpeg2video] Invalid frame dimensions 0x0` even though the dimensions are correctly set in the metadata. I added some more logging during subscription starts so the video dimensions sent by tvheadend can be seen clearly. As can be seen from http://pastebin.com/ME9j7ZsQ, even though `PVR_STREAM::iWidth` and `PVR_STREAM::iHeight` are set to `720x576` the dimensions are later determined to be `0x0` by ffmpeg.

This is an attempt to fix that by making sure the next packet in the buffer after a stream change packet is always an I-frame.

@perexg @FernetMenta @fritsch do you think this looks right or could there still be something I haven't accounted for?
