### PR TITLE
Build pvr.hts branch Jarvis against updated p8platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,10 @@ enable_language(CXX)
 
 find_package(kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
-find_package(platform REQUIRED)
+find_package(p8-platform REQUIRED)
 
 include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${platform_INCLUDE_DIRS}
+                    ${p8-platform_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR}
                     ${PROJECT_SOURCE_DIR}/lib)
 
@@ -95,7 +95,7 @@ list(APPEND HTS_SOURCES
 
 add_subdirectory(lib/libhts)
 
-set(DEPLIBS ${platform_LIBRARIES} hts)
+set(DEPLIBS ${p8-platform_LIBRARIES} hts)
 if(WIN32)
   list(APPEND DEPLIBS ws2_32)
 endif()

--- a/src/AutoRecordings.cpp
+++ b/src/AutoRecordings.cpp
@@ -26,7 +26,7 @@
 #include "tvheadend/utilities/Utilities.h"
 #include "tvheadend/utilities/Logger.h"
 
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 using namespace tvheadend;
 using namespace tvheadend::entity;
 using namespace tvheadend::utilities;

--- a/src/HTSPConnection.cpp
+++ b/src/HTSPConnection.cpp
@@ -19,9 +19,9 @@
  *
  */
 
-#include "platform/threads/mutex.h"
-#include "platform/util/StringUtils.h"
-#include "platform/sockets/tcp.h"
+#include "p8-platform/threads/mutex.h"
+#include "p8-platform/util/StringUtils.h"
+#include "p8-platform/sockets/tcp.h"
 
 extern "C" {
 #include "libhts/htsmsg_binary.h"
@@ -33,7 +33,7 @@ extern "C" {
 
 using namespace std;
 using namespace ADDON;
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 using namespace tvheadend;
 using namespace tvheadend::utilities;
 

--- a/src/HTSPDemuxer.cpp
+++ b/src/HTSPDemuxer.cpp
@@ -27,7 +27,7 @@
 
 using namespace std;
 using namespace ADDON;
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 using namespace tvheadend;
 using namespace tvheadend::utilities;
 

--- a/src/HTSPVFS.cpp
+++ b/src/HTSPVFS.cpp
@@ -19,8 +19,8 @@
  *
  */
 
-#include "platform/threads/mutex.h"
-#include "platform/util/StringUtils.h"
+#include "p8-platform/threads/mutex.h"
+#include "p8-platform/util/StringUtils.h"
 #include "tvheadend/utilities/Logger.h"
 
 extern "C" {
@@ -30,7 +30,7 @@ extern "C" {
 #include "Tvheadend.h"
 
 using namespace std;
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 using namespace tvheadend::utilities;
 
 /*

--- a/src/TimeRecordings.cpp
+++ b/src/TimeRecordings.cpp
@@ -25,7 +25,7 @@
 #include "tvheadend/utilities/Utilities.h"
 #include "tvheadend/utilities/Logger.h"
 
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 using namespace tvheadend;
 using namespace tvheadend::entity;
 using namespace tvheadend::utilities;

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -23,7 +23,7 @@
 #include <ctime>
 #include <memory>
 
-#include "platform/util/StringUtils.h"
+#include "p8-platform/util/StringUtils.h"
 
 #include "Tvheadend.h"
 #include "tvheadend/utilities/Utilities.h"
@@ -31,7 +31,7 @@
 
 using namespace std;
 using namespace ADDON;
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 using namespace tvheadend;
 using namespace tvheadend::entity;
 using namespace tvheadend::utilities;

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -22,10 +22,10 @@
  */
 
 #include "client.h"
-#include "platform/sockets/tcp.h"
-#include "platform/threads/threads.h"
-#include "platform/threads/mutex.h"
-#include "platform/util/buffer.h"
+#include "p8-platform/sockets/tcp.h"
+#include "p8-platform/threads/threads.h"
+#include "p8-platform/threads/mutex.h"
+#include "p8-platform/util/buffer.h"
 #include "kodi/xbmc_codec_types.h"
 #include "kodi/xbmc_stream_utils.hpp"
 #include "kodi/libXBMC_addon.h"
@@ -88,7 +88,7 @@ class CHTSPMessage;
 
 /* Typedefs */
 typedef std::map<uint32_t,CHTSPResponse*> CHTSPResponseList;
-typedef PLATFORM::SyncedBuffer<CHTSPMessage> CHTSPMessageQueue;
+typedef P8PLATFORM::SyncedBuffer<CHTSPMessage> CHTSPMessageQueue;
 
 /*
  * HTSP Response handler
@@ -98,10 +98,10 @@ class CHTSPResponse
 public:
   CHTSPResponse();
   ~CHTSPResponse();
-  htsmsg_t *Get ( PLATFORM::CMutex &mutex, uint32_t timeout );
+  htsmsg_t *Get ( P8PLATFORM::CMutex &mutex, uint32_t timeout );
   void      Set ( htsmsg_t *m );
 private:
-  PLATFORM::CCondition<volatile bool> m_cond;
+  P8PLATFORM::CCondition<volatile bool> m_cond;
   bool                                m_flag;
   htsmsg_t                           *m_msg;
 };
@@ -146,7 +146,7 @@ public:
  * HTSP Connection registration thread
  */
 class CHTSPRegister
-  : public PLATFORM::CThread
+  : public P8PLATFORM::CThread
 {
   friend class CHTSPConnection;
 
@@ -163,7 +163,7 @@ private:
  * HTSP Connection
  */
 class CHTSPConnection
-  : public PLATFORM::CThread
+  : public P8PLATFORM::CThread
 {
   friend class CHTSPRegister;
 
@@ -190,7 +190,7 @@ public:
   inline bool IsConnected       ( void ) const { return m_ready; }
   bool        WaitForConnection ( void );
 
-  inline PLATFORM::CMutex& Mutex ( void ) { return m_mutex; }
+  inline P8PLATFORM::CMutex& Mutex ( void ) { return m_mutex; }
 
   void        OnSleep ( void );
   void        OnWake  ( void );
@@ -202,10 +202,10 @@ private:
   bool        SendHello        ( void );
   bool        SendAuth         ( const std::string &u, const std::string &p );
 
-  PLATFORM::CTcpSocket               *m_socket;
-  PLATFORM::CMutex                    m_mutex;
+  P8PLATFORM::CTcpSocket               *m_socket;
+  P8PLATFORM::CMutex                    m_mutex;
   CHTSPRegister                       m_regThread;
-  PLATFORM::CCondition<volatile bool> m_regCond;
+  P8PLATFORM::CCondition<volatile bool> m_regCond;
   bool                                m_ready;
   uint32_t                            m_seq;
   std::string                         m_serverName;
@@ -273,13 +273,13 @@ public:
   void SetStreamingProfile(const std::string &profile);
 
 private:
-  PLATFORM::CMutex                        m_mutex;
+  P8PLATFORM::CMutex                        m_mutex;
   CHTSPConnection                        &m_conn;
-  PLATFORM::SyncedBuffer<DemuxPacket*>    m_pktBuffer;
+  P8PLATFORM::SyncedBuffer<DemuxPacket*>    m_pktBuffer;
   ADDON::XbmcStreamProperties             m_streams;
   std::map<int,int>                       m_streamStat;
   int64_t                                 m_seekTime;
-  PLATFORM::CCondition<volatile int64_t>  m_seekCond;
+  P8PLATFORM::CCondition<volatile int64_t>  m_seekCond;
   bool                                    m_seeking;
   bool                                    m_speedChange;
   tvheadend::status::SourceInfo           m_sourceInfo;
@@ -350,7 +350,7 @@ private:
  * Root object for Tvheadend connection
  */
 class CTvheadend
-  : public PLATFORM::CThread
+  : public P8PLATFORM::CThread
 {
 public:
   CTvheadend();
@@ -422,7 +422,7 @@ private:
    */
   tvheadend::Profiles         m_profiles;
 
-  PLATFORM::CMutex            m_mutex;
+  P8PLATFORM::CMutex            m_mutex;
 
   CHTSPConnection             m_conn;
 
@@ -519,7 +519,7 @@ public:
    */
   bool WaitForConnection ( void )
   {
-    PLATFORM::CLockObject lock(m_conn.Mutex());
+    P8PLATFORM::CLockObject lock(m_conn.Mutex());
     return m_conn.WaitForConnection();
   }
   std::string GetServerName    ( void )

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -22,14 +22,14 @@
 #include "client.h"
 #include "kodi/xbmc_pvr_dll.h"
 #include "kodi/libKODI_guilib.h"
-#include "platform/util/util.h"
+#include "p8-platform/util/util.h"
 #include "Tvheadend.h"
 #include "tvheadend/Settings.h"
 #include "tvheadend/utilities/Logger.h"
 
 using namespace std;
 using namespace ADDON;
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 using namespace tvheadend;
 using namespace tvheadend::utilities;
 

--- a/src/client.h
+++ b/src/client.h
@@ -20,8 +20,8 @@
  *
  */
 
-#include "platform/os.h"
-#include "platform/threads/mutex.h"
+#include "p8-platform/os.h"
+#include "p8-platform/threads/mutex.h"
 #include "kodi/libXBMC_addon.h"
 #include "kodi/libXBMC_pvr.h"
 #include "kodi/libXBMC_codec.h"

--- a/src/tvheadend/Subscription.cpp
+++ b/src/tvheadend/Subscription.cpp
@@ -23,7 +23,7 @@
 #include "utilities/Logger.h"
 #include "../Tvheadend.h"
 
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 using namespace tvheadend;
 using namespace tvheadend::utilities;
 

--- a/src/tvheadend/Subscription.h
+++ b/src/tvheadend/Subscription.h
@@ -22,7 +22,7 @@
  */
 
 #include <string>
-#include "platform/threads/mutex.h"
+#include "p8-platform/threads/mutex.h"
 
 extern "C"
 {
@@ -146,6 +146,6 @@ namespace tvheadend
     std::string       m_profile;
     CHTSPConnection   &m_conn;
 
-    mutable PLATFORM::CMutex  m_mutex;
+    mutable P8PLATFORM::CMutex  m_mutex;
   };
 }

--- a/src/tvheadend/utilities/AsyncState.cpp
+++ b/src/tvheadend/utilities/AsyncState.cpp
@@ -22,7 +22,7 @@
 #include "AsyncState.h"
 
 using namespace tvheadend::utilities;
-using namespace PLATFORM;
+using namespace P8PLATFORM;
 
 struct Param {
   eAsyncState state;
@@ -37,7 +37,7 @@ AsyncState::AsyncState(int timeout)
 
 eAsyncState AsyncState::GetState()
 {
-  PLATFORM::CLockObject lock(m_mutex);
+  P8PLATFORM::CLockObject lock(m_mutex);
   return m_state;
 }
 

--- a/src/tvheadend/utilities/AsyncState.h
+++ b/src/tvheadend/utilities/AsyncState.h
@@ -22,7 +22,7 @@
 #ifndef ASYNCSTATE_H
 #define	ASYNCSTATE_H
 
-#include "platform/threads/mutex.h"
+#include "p8-platform/threads/mutex.h"
 
 namespace tvheadend {
   namespace utilities {
@@ -75,8 +75,8 @@ namespace tvheadend {
       static bool PredicateCallback ( void *param );
 
       eAsyncState m_state;
-      PLATFORM::CMutex m_mutex;
-      PLATFORM::CCondition<bool> m_condition;
+      P8PLATFORM::CMutex m_mutex;
+      P8PLATFORM::CCondition<bool> m_condition;
       int m_timeout;
 
     };


### PR DESCRIPTION
The build instructions in 09657735eae33bd85bb8324cb44f90de97e519a9 won't work on the Jarvis branch without this backport.