### PR TITLE
Pass empty string instead off NULL

### DIFF
--- a/src/HTSPConnection.cpp
+++ b/src/HTSPConnection.cpp
@@ -216,7 +216,7 @@ void CHTSPConnection::SetState ( PVR_CONNECTION_STATE state )
   if (prevState != newState)
   {
     /* Notify connection state change (callback!) */
-    PVR->ConnectionStateChange(GetServerString().c_str(), newState, NULL);
+    PVR->ConnectionStateChange(GetServerString().c_str(), newState, "");
   }
 }
 


### PR DESCRIPTION
According to the description in the file, **./xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_pvr.h**,
the last parameter (strMessage) can be NULL, however, when passing
NULL to ConnectionStateChange(), kodi core dumps as soon as the
function is called. Suggestion is to pass an empty string instead.

`
'terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
Aborted (core dumped)'
`