### PR TITLE
Fix async state handling.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="3.3.0"
+  version="3.3.1"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+3.3.1
+- Fixed a problem with async state handling that could happen when restoring a lost connection to tvheadend.
+
 3.3.0
 - Updated to PVR API v5.2.0
 


### PR DESCRIPTION
I stumbled over a weird problem while debugging sporadic wrong timer deleted notifications. General fix is here https://github.com/xbmc/xbmc/pull/9655

But there are more problems leading to wrong notifications, for instance this on in pvr.hts:

0. kodi running, pvr.hts connected to tvh, all good
1. pvr.hts successfully processes at least one <code>GetTimers</code> call, returned at least one timer: https://github.com/kodi-pvr/pvr.hts/blob/master/src/Tvheadend.cpp#L930 
2. async epg event updates are pushed from tvh and queued for processing in pvr.hts: https://github.com/kodi-pvr/pvr.hts/blob/master/src/Tvheadend.cpp#L1401
3. now connection to tvh gets lost (for me, automatic disconnect/reconnect on getDiskSpace htsp call not returning in time) and pvr.hts automatically tries to reconnect to tvh
4. when connection is reestablished async state is set to NONE and all items (including recordings/timers) are marked dirty: https://github.com/kodi-pvr/pvr.hts/blob/master/src/Tvheadend.cpp#L1355
5. concurrently, the epg event update messages queued from the previous connection are processed, which is basically okay: https://github.com/kodi-pvr/pvr.hts/blob/master/src/Tvheadend.cpp#L1418
6. in this context <code>SyncDvrCompleted</code> will be called: https://github.com/kodi-pvr/pvr.hts/blob/master/src/Tvheadend.cpp#L2065
7. this method sets the async epg state to EPG, and if no recording/timer updates are pushed by the new connection at this time (which happened from time to time for me), all recordings/timers will be deleted from pvr.hts data structures because they are all still flagged dirty.
8. Finally, if in this state Kodi issues a <code>GetTimers</code> call, this call will return NO_ERROR, but no timers.
9. the latter leads to timer deleted notifications in Kodi!

Reason for all this are some simple but essential flaws with current implementation of the async state machine of pvr.hts the PR tries to fix.