### PR TITLE
Fix instant timers.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="3.4.0"
+  version="3.4.1"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+3.4.1
+- Fix instant timers
+
 3.4.0
 - Cmake: rename find_package kodi to Kodi
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -976,7 +976,9 @@ PVR_ERROR CTvheadend::AddTimer ( const PVR_TIMER &timer )
 
     /* Build message */
     htsmsg_t *m = htsmsg_create_map();
-    if (timer.iEpgUid > PVR_TIMER_NO_EPG_UID && timer.iTimerType == TIMER_ONCE_EPG)
+
+    int64_t start = timer.startTime;
+    if (timer.iEpgUid > PVR_TIMER_NO_EPG_UID && timer.iTimerType == TIMER_ONCE_EPG && start != 0)
     {
       /* EPG-based timer */
       htsmsg_add_u32(m, "eventId",      timer.iEpgUid);
@@ -986,7 +988,6 @@ PVR_ERROR CTvheadend::AddTimer ( const PVR_TIMER &timer )
       /* manual timer */
       htsmsg_add_str(m, "title",        timer.strTitle);
 
-      int64_t start = timer.startTime;
       if (start == 0)
       {
         /* Instant timer. Adjust start time to 'now'. */


### PR DESCRIPTION
Instant timers are actually manual timers, esp. start and end time, no matter they are created from epg tags. => https://github.com/xbmc/xbmc/blob/master/xbmc/pvr/timers/PVRTimerInfoTag.cpp#L790

@Jalle19 good to go?