### PR TITLE
HTSP v25 additions

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="3.4.2"
+  version="3.4.3"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,7 @@
+3.4.3
+- improved: only show real radio and TV channels in Kodi
+- improved: recording handling when it's channel doesn't exist anymore (HTSP v25 and above)
+
 3.4.2
 - updated language files from Transifex
 

--- a/src/HTSPTypes.h
+++ b/src/HTSPTypes.h
@@ -80,6 +80,12 @@ typedef enum {
   DVR_RET_FOREVER   = INT32_MAX     // the server should never delete this recording or database entry, only the user can do this
 } dvr_retention_t;
 
+typedef enum {
+  CHANNEL_TYPE_OTHER = 0,
+  CHANNEL_TYPE_TV    = 1,
+  CHANNEL_TYPE_RADIO = 2
+} channel_type_t;
+
 enum eHTSPEventType
 {
   HTSP_EVENT_NONE = 0,

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1841,7 +1841,7 @@ void CTvheadend::ParseChannelAddOrUpdate ( htsmsg_t *msg, bool bAdd )
         {
           if (!strcmp(str, "Radio"))
             channel.SetType(CHANNEL_TYPE_RADIO);
-          else
+          else if (!strcmp(str, "SDTV") || !strcmp(str, "HDTV"))
             channel.SetType(CHANNEL_TYPE_TV);
         }
       }

--- a/src/tvheadend/entity/Channel.h
+++ b/src/tvheadend/entity/Channel.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <map>
 #include "Entity.h"
+#include "../../HTSPTypes.h"
 
 namespace tvheadend
 {
@@ -44,7 +45,7 @@ namespace tvheadend
       Channel() :
         m_num(0),
         m_numMinor(0),
-        m_radio(false),
+        m_type(CHANNEL_TYPE_OTHER),
         m_caid(0)
       {
       }
@@ -59,7 +60,7 @@ namespace tvheadend
         return m_id == other.m_id &&
                m_num == other.m_num &&
                m_numMinor == other.m_numMinor &&
-               m_radio == other.m_radio &&
+               m_type == other.m_type &&
                m_caid == other.m_caid &&
                m_name == other.m_name &&
                m_icon == other.m_icon;
@@ -76,8 +77,8 @@ namespace tvheadend
       uint32_t GetNumMinor() const { return m_numMinor; }
       void SetNumMinor(uint32_t numMinor) { m_numMinor = numMinor; }
 
-      bool IsRadio() const { return m_radio; }
-      void SetRadio(bool radio) { m_radio = radio; }
+      uint32_t GetType() const { return m_type; }
+      void SetType(uint32_t type) { m_type = type; }
 
       uint32_t GetCaid() const { return m_caid; }
       void SetCaid(uint32_t caid) { m_caid = caid; }
@@ -91,7 +92,7 @@ namespace tvheadend
     private:
       uint32_t         m_num;
       uint32_t         m_numMinor;
-      bool             m_radio;
+      uint32_t         m_type;
       uint32_t         m_caid;
       std::string      m_name;
       std::string      m_icon;

--- a/src/tvheadend/entity/Recording.h
+++ b/src/tvheadend/entity/Recording.h
@@ -55,6 +55,7 @@ namespace tvheadend
       Recording() :
         m_enabled(0),
         m_channel(0),
+        m_channelType(0),
         m_eventId(0),
         m_start(0),
         m_stop(0),
@@ -71,6 +72,8 @@ namespace tvheadend
         return m_id == other.m_id &&
                m_enabled == other.m_enabled &&
                m_channel == other.m_channel &&
+               m_channelType == other.m_channelType &&
+               m_channelName == other.m_channelName &&
                m_eventId == other.m_eventId &&
                m_start == other.m_start &&
                m_stop == other.m_stop &&
@@ -128,6 +131,12 @@ namespace tvheadend
       uint32_t GetChannel() const { return m_channel; }
       void SetChannel(uint32_t channel) { m_channel = channel; }
 
+      uint32_t GetChannelType() const { return m_channelType; }
+      void SetChannelType(uint32_t channelType) { m_channelType = channelType; }
+
+      const std::string& GetChannelName() const { return m_channelName; }
+      void SetChannelName(const std::string &channelName) { m_channelName = channelName; }
+
       uint32_t GetEventId() const { return m_eventId; }
       void SetEventId(uint32_t eventId) { m_eventId = eventId; }
 
@@ -181,6 +190,8 @@ namespace tvheadend
     private:
       uint32_t         m_enabled;
       uint32_t         m_channel;
+      uint32_t         m_channelType;
+      std::string      m_channelName;
       uint32_t         m_eventId;
       int64_t          m_start;
       int64_t          m_stop;

--- a/src/tvheadend/entity/Tag.cpp
+++ b/src/tvheadend/entity/Tag.cpp
@@ -21,7 +21,6 @@
 
 #include "Tag.h"
 #include "Channel.h"
-#include "../../HTSPTypes.h"
 #include "../../Tvheadend.h"
 
 using namespace tvheadend::entity;
@@ -80,7 +79,7 @@ std::vector<uint32_t>& Tag::GetChannels()
   return m_channels;
 }
 
-bool Tag::ContainsChannelType(bool bRadio) const
+bool Tag::ContainsChannelType(channel_type_t eType) const
 {
   std::vector<uint32_t>::const_iterator it;
   Channels::const_iterator cit;
@@ -90,7 +89,7 @@ bool Tag::ContainsChannelType(bool bRadio) const
   {
     if ((cit = channels.find(*it)) != channels.end())
     {
-      if (bRadio == cit->second.IsRadio())
+      if (cit->second.GetType() == eType)
         return true;
     }
   }

--- a/src/tvheadend/entity/Tag.h
+++ b/src/tvheadend/entity/Tag.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <vector>
 #include "Entity.h"
+#include "../../HTSPTypes.h"
 
 namespace tvheadend
 {
@@ -57,7 +58,7 @@ namespace tvheadend
       const std::vector<uint32_t>& GetChannels() const;
       std::vector<uint32_t>& GetChannels();
 
-      bool ContainsChannelType(bool bRadio) const;
+      bool ContainsChannelType(channel_type_t eType) const;
 
     private:
       uint32_t              m_index;


### PR DESCRIPTION
Changes:
1) bIsRadio -> channelType: channelType can have 'radio', 'tv' or 'other' assigned to it. By this way, we can hide all channels marked as 'other' from Kodi. With the current implementation, channels with data/download services where shown as tv channels in Kodi...
2) Recordings with a deleted channel are now correctly identified as radio/television and the channel name will still be present. 
The current implementation just maps everything to tv recordings in this case.

@ksooo Part 2 is the one you requested some time ago.