### PR TITLE
Fix setting channel type & setting epg uid

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="3.4.3"
+  version="3.4.4"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,7 @@
+3.4.4
+- fixed: setting channel type for 'early' htsp v25 servers
+- fixed: setting epg uid for timers
+
 3.4.3
 - improved: only show real radio and TV channels in Kodi
 - improved: recording handling when it's channel doesn't exist anymore (HTSP v25 and above)

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1818,12 +1818,20 @@ void CTvheadend::ParseChannelAddOrUpdate ( htsmsg_t *msg, bool bAdd )
         continue;
 
       /* Channel type */
+      bool bGotContent = false;
       if (m_conn.GetProtocol() >= 25)
       {
         if (!htsmsg_get_u32(&f->hmf_msg, "content", &u32))
+        {
           channel.SetType(u32);
+          bGotContent = true;
+        }
       }
-      else
+
+      // The 'content' htsp method field was added to tvheadend htsp api without htsp version bump.
+      // Unfortunately, there are many semi-official tvheadend builds with htsp version 25 in the wild which
+      // do not support the 'content' htsp attribute. Just checking htsp api version is not sufficient. :-/
+      if (!bGotContent)
       {
         if ((str = htsmsg_get_str(&f->hmf_msg, "type")) != NULL)
         {

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -912,7 +912,7 @@ bool CTvheadend::CreateTimer ( const Recording &tvhTmr, PVR_TIMER &tmr )
   tmr.iPreventDuplicateEpisodes = 0;         // n/a for one-shot timers
   tmr.firstDay           = 0;                // not supported by tvh
   tmr.iWeekdays          = PVR_WEEKDAY_NONE; // n/a for one-shot timers
-  tmr.iEpgUid            = (tvhTmr.GetEventId() > 0) ? tvhTmr.GetEventId() : -1;
+  tmr.iEpgUid            = (tvhTmr.GetEventId() > 0) ? tvhTmr.GetEventId() : PVR_TIMER_NO_EPG_UID;
   tmr.iMarginStart       = static_cast<unsigned int>(tvhTmr.GetStartExtra());
   tmr.iMarginEnd         = static_cast<unsigned int>(tvhTmr.GetStopExtra());
   tmr.iGenreType         = 0;                // not supported by tvh?


### PR DESCRIPTION
@Glenn-1990 fyi. for commit 1, please note my comment in the code regarding the evil of adding new functionality to htsp api without bumping htsp version. :-/

@seo @da-anda this brings pvr.hts back to life for you (and me) and probably many others using latest 'official' tvheadend raspberry build (dated january 2016 or so).