### PR TITLE
Close the demuxer in the destructor

### DIFF
--- a/src/HTSPDemuxer.cpp
+++ b/src/HTSPDemuxer.cpp
@@ -41,6 +41,7 @@ CHTSPDemuxer::CHTSPDemuxer ( CHTSPConnection &conn )
 
 CHTSPDemuxer::~CHTSPDemuxer ()
 {
+  Close();
 }
 
 void CHTSPDemuxer::Connected ( void )


### PR DESCRIPTION
The mux packet parsing and the object destruction happens on different threads, so m_subscription may be incorrectly accessed by one of them. This should hopefully fix that by closing the demuxer properly.

Possible fixes #235

Haven't runtime tested this yet, will do shortly.
