### PR TITLE
Bugfix/epg loading time improvements

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="3.4.7"
+  version="3.4.8"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+3.4.8
+- improve EPG loading performance
+
 3.4.7
 - updated language files from Transifex
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1261,8 +1261,9 @@ PVR_ERROR CTvheadend::GetEpg
 {
   htsmsg_field_t *f;
 
-  Logger::Log(LogLevel::LEVEL_TRACE, "get epg channel %d start %ld stop %ld", chn.iUniqueId,
+  Logger::Log(LogLevel::LEVEL_DEBUG, "get epg channel %d start %ld stop %ld", chn.iUniqueId,
            (long long)start, (long long)end);
+
 
   /* Note: Nothing to do if "async epg transfer" is enabled as all changes are pushed live to Kodi, then. */
   if (!Settings::GetInstance().GetAsyncEpg())
@@ -1306,7 +1307,11 @@ PVR_ERROR CTvheadend::GetEpg
       }
     }
     htsmsg_destroy(msg);
-    Logger::Log(LogLevel::LEVEL_TRACE, "get epg channel %d events %d", chn.iUniqueId, n);
+    Logger::Log(LogLevel::LEVEL_DEBUG, "get epg channel %d events %d", chn.iUniqueId, n);
+  }
+  else
+  {
+    Logger::Log(LogLevel::LEVEL_DEBUG, "get epg channel %d ignored", chn.iUniqueId);
   }
   return PVR_ERROR_NO_ERROR;
 }
@@ -1364,6 +1369,7 @@ bool CTvheadend::Connected ( void )
   msg = htsmsg_create_map();
   if (Settings::GetInstance().GetAsyncEpg())
   {
+    Logger::Log(LogLevel::LEVEL_INFO, "request async EPG (%ld)", (long)m_epgMaxDays);
     htsmsg_add_u32(msg, "epg", 1);
     if (m_epgMaxDays > EPG_TIMEFRAME_UNLIMITED)
       htsmsg_add_s64(msg, "epgMaxTime", static_cast<int64_t>(time(NULL) + m_epgMaxDays * int64_t(24 * 60 *60)));
@@ -1378,7 +1384,7 @@ bool CTvheadend::Connected ( void )
   }
 
   htsmsg_destroy(msg);
-  Logger::Log(LogLevel::LEVEL_DEBUG, "async updates requested");
+  Logger::Log(LogLevel::LEVEL_INFO, "async updates requested");
 
   return true;
 }
@@ -1544,6 +1550,8 @@ void* CTvheadend::Process ( void )
 
 void CTvheadend::SyncCompleted ( void )
 {
+  Logger::Log(LogLevel::LEVEL_INFO, "async updates initialised");
+
   /* The complete calls are probably redundant, but its a safety feature */
   SyncChannelsCompleted();
   SyncDvrCompleted();

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -2217,16 +2217,8 @@ bool CTvheadend::ParseEvent ( htsmsg_t *msg, bool bAdd, Event &evt )
     evt.SetPart(u32);
 
   /* Add optional recording link */
-  auto rit = std::find_if(
-    m_recordings.cbegin(), 
-    m_recordings.cend(), 
-    [evt](const RecordingMapEntry &entry)
-  {
-    return entry.second.GetEventId() == evt.GetId();
-  });
-
-  if (rit != m_recordings.cend())
-    evt.SetRecordingId(evt.GetId());
+  if (!htsmsg_get_u32(msg, "dvrId", &u32))
+    evt.SetRecordingId(u32);
   
   return true;
 }


### PR DESCRIPTION
When through a few variations in trying to figure out the performance issues and then improve, but in the end it would have probably been simpler just to use the solution from the final commit and just that.

But hey ho, it's MUCH faster than before and "almost" tolerable now. I think any additional delays are out of pvr.hts control.