### PR TITLE
Fix libXBMC_codec.h include path

### DIFF
--- a/src/xbmc_codec_descriptor.hpp
+++ b/src/xbmc_codec_descriptor.hpp
@@ -20,7 +20,7 @@
 #ifndef XBMC_CODEC_DESCRIPTOR_HPP
 #define	XBMC_CODEC_DESCRIPTOR_HPP
 
-#include "kodi/libXBMC_codec.h"
+#include "libXBMC_codec.h"
 
 /**
  * Adapter which converts codec names used by tvheadend and VDR into their 


### PR DESCRIPTION
This PR changes the include path for `libXBMC_codec.h` to make it easier to build this binary addon when Kodi's app name have been changed.

`${KODI_INCLUDE_DIR}` @ https://github.com/kodi-pvr/pvr.hts/blob/Krypton/CMakeLists.txt#L13 already points to the `kodi` folder and to an app-named include folder in my case.