### PR TITLE
Store streams in a vector instead of a C array

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.0.1"
+  version="4.0.2"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,9 @@
+4.0.2
+- updated build instructions in the README
+- fixed Travis CI and AppVeyor automated builds
+- fixed a bunch of cast warnings
+- cleanup stream handling somewhat
+
 4.0.1
 - updated language files from Transifex
 

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.0.1
+- updated language files from Transifex
+
 4.0.0
 - Initial Kodi v18 version
 

--- a/src/HTSPDemuxer.cpp
+++ b/src/HTSPDemuxer.cpp
@@ -74,7 +74,7 @@ void CHTSPDemuxer::Close0 ( void )
 void CHTSPDemuxer::Abort0 ( void )
 {
   CLockObject lock(m_mutex);
-  m_streams.iStreamCount = 0;
+  m_streams.clear();
   m_streamStat.clear();
   m_seeking = false;
   m_speedChange = false;
@@ -210,12 +210,13 @@ void CHTSPDemuxer::Weight ( enum eSubscriptionWeight weight )
 PVR_ERROR CHTSPDemuxer::CurrentStreams ( PVR_STREAM_PROPERTIES *props )
 {
   CLockObject lock(m_mutex);
-  for (int i = 0; i < m_streams.iStreamCount; i++)
+
+  for (size_t i = 0; i < m_streams.size(); i++)
   {
-    memcpy(&props->stream[i], &m_streams.stream[i], sizeof(PVR_STREAM_PROPERTIES::PVR_STREAM));
+    memcpy(&props->stream[i], &m_streams.at(i), sizeof(PVR_STREAM_PROPERTIES::PVR_STREAM));
   }
 
-  props->iStreamCount = m_streams.iStreamCount;
+  props->iStreamCount = static_cast<unsigned int>(m_streams.size());
   return PVR_ERROR_NO_ERROR;
 }
 
@@ -436,10 +437,11 @@ void CHTSPDemuxer::ParseSubscriptionStart ( htsmsg_t *m )
     return;
   }
   m_streamStat.clear();
-  m_streams.iStreamCount = 0;
+  m_streams.clear();
+
+  Logger::Log(LogLevel::LEVEL_DEBUG, "demux subscription start");
 
   /* Process each */
-  int count = 0;
   HTSMSG_FOREACH(f, l)
   {
     uint32_t   idx, u32;
@@ -454,82 +456,87 @@ void CHTSPDemuxer::ParseSubscriptionStart ( htsmsg_t *m )
 
     /* Find stream */
     m_streamStat[idx] = 0;
+    PVR_STREAM_PROPERTIES::PVR_STREAM stream = {};
+
     Logger::Log(LogLevel::LEVEL_DEBUG, "demux subscription start");
     
     CodecDescriptor codecDescriptor = CodecDescriptor::GetCodecByName(type);
     xbmc_codec_t codec = codecDescriptor.Codec();
 
-    memset(&m_streams.stream[count], 0, sizeof(m_streams.stream[count]));
-
     if (codec.codec_type != XBMC_CODEC_TYPE_UNKNOWN)
     {
-      m_streams.stream[count].iCodecType = codec.codec_type;
-      m_streams.stream[count].iCodecId   = codec.codec_id;
-      m_streams.stream[count].iPID       = idx;
+      stream.iCodecType = codec.codec_type;
+      stream.iCodecId   = codec.codec_id;
+      stream.iPID       = idx;
 
       /* Subtitle ID */
-      if ((m_streams.stream[count].iCodecType == XBMC_CODEC_TYPE_SUBTITLE) &&
+      if ((stream.iCodecType == XBMC_CODEC_TYPE_SUBTITLE) &&
           !strcmp("DVBSUB", type))
       {
         uint32_t composition_id = 0, ancillary_id = 0;
         htsmsg_get_u32(&f->hmf_msg, "composition_id", &composition_id);
         htsmsg_get_u32(&f->hmf_msg, "ancillary_id"  , &ancillary_id);
-        m_streams.stream[count].iSubtitleInfo = (composition_id & 0xffff)
-                                              | ((ancillary_id & 0xffff) << 16);
+        stream.iSubtitleInfo = (composition_id & 0xffff) | ((ancillary_id & 0xffff) << 16);
       }
 
       /* Language */
-      if (m_streams.stream[count].iCodecType == XBMC_CODEC_TYPE_SUBTITLE ||
-          m_streams.stream[count].iCodecType == XBMC_CODEC_TYPE_AUDIO)
+      if (stream.iCodecType == XBMC_CODEC_TYPE_SUBTITLE ||
+          stream.iCodecType == XBMC_CODEC_TYPE_AUDIO)
       {
         const char *language;
         
         if ((language = htsmsg_get_str(&f->hmf_msg, "language")) != NULL)
-          strncpy(m_streams.stream[count].strLanguage, language, sizeof(m_streams.stream[count].strLanguage) - 1);
+          strncpy(stream.strLanguage, language, sizeof(stream.strLanguage) - 1);
       }
 
       /* Audio data */
-      if (m_streams.stream[count].iCodecType == XBMC_CODEC_TYPE_AUDIO)
+      if (stream.iCodecType == XBMC_CODEC_TYPE_AUDIO)
       {
-        m_streams.stream[count].iChannels
-          = htsmsg_get_u32_or_default(&f->hmf_msg, "channels", 2);
-        m_streams.stream[count].iSampleRate
-          = htsmsg_get_u32_or_default(&f->hmf_msg, "rate", 48000);
+        stream.iChannels = htsmsg_get_u32_or_default(&f->hmf_msg, "channels", 2);
+        stream.iSampleRate = htsmsg_get_u32_or_default(&f->hmf_msg, "rate", 48000);
       }
 
       /* Video */
-      if (m_streams.stream[count].iCodecType == XBMC_CODEC_TYPE_VIDEO)
+      if (stream.iCodecType == XBMC_CODEC_TYPE_VIDEO)
       {
-        m_streams.stream[count].iWidth  = htsmsg_get_u32_or_default(&f->hmf_msg, "width", 0);
-        m_streams.stream[count].iHeight = htsmsg_get_u32_or_default(&f->hmf_msg, "height", 0);
+        stream.iWidth  = htsmsg_get_u32_or_default(&f->hmf_msg, "width", 0);
+        stream.iHeight = htsmsg_get_u32_or_default(&f->hmf_msg, "height", 0);
         
         /* Ignore this message if the stream details haven't been determined 
            yet, a new message will be sent once they have. This is fixed in 
            some versions of tvheadend and is here for backward compatibility. */
-        if (m_streams.stream[count].iWidth == 0 || m_streams.stream[count].iHeight == 0)
+        if (stream.iWidth == 0 || stream.iHeight == 0)
         {
           Logger::Log(LogLevel::LEVEL_DEBUG, "Ignoring subscriptionStart, stream details missing");
           return;
         }
         
         /* Setting aspect ratio to zero will cause XBMC to handle changes in it */
-        m_streams.stream[count].fAspect = 0.0f;
+        stream.fAspect = 0.0f;
         
         if ((u32 = htsmsg_get_u32_or_default(&f->hmf_msg, "duration", 0)) > 0)
         {
-          m_streams.stream[count].iFPSScale = u32;
-          m_streams.stream[count].iFPSRate  = DVD_TIME_BASE;
+          stream.iFPSScale = u32;
+          stream.iFPSRate  = DVD_TIME_BASE;
         }
       }
-        
-      Logger::Log(LogLevel::LEVEL_DEBUG, "  id: %d, type %s, codec: %u", idx, type, m_streams.stream[count].iCodecId);
-      count++;
+
+      /* We can only use PVR_STREAM_MAX_STREAMS streams */
+      if (m_streams.size() < PVR_STREAM_MAX_STREAMS)
+      {
+        Logger::Log(LogLevel::LEVEL_DEBUG, "  id: %d, type %s, codec: %u", idx, type, stream.iCodecId);
+        m_streams.push_back(stream);
+      }
+      else
+      {
+        Logger::Log(LogLevel::LEVEL_INFO, "Maximum stream limit reached ignoring id: %d, type %s, codec: %u", idx, type,
+                    stream.iCodecId);
+      }
     }
   }
 
   /* Update streams */
   Logger::Log(LogLevel::LEVEL_DEBUG, "demux stream change");
-  m_streams.iStreamCount = count;
   pkt = PVR->AllocateDemuxPacket(0);
   pkt->iStreamId = DMX_SPECIALID_STREAMCHANGE;
   m_pktBuffer.Push(pkt);

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -256,7 +256,7 @@ private:
   mutable P8PLATFORM::CMutex              m_mutex;
   CHTSPConnection                        &m_conn;
   P8PLATFORM::SyncedBuffer<DemuxPacket*>  m_pktBuffer;
-  PVR_STREAM_PROPERTIES                   m_streams;
+  std::vector<PVR_STREAM_PROPERTIES::PVR_STREAM> m_streams;
   std::map<int,int>                       m_streamStat;
   int64_t                                 m_seekTime;
   P8PLATFORM::CCondition<volatile int64_t>  m_seekCond;


### PR DESCRIPTION
Also cap the streams at PVR_STREAMS_MAX_STREAMS. 

Closes #204, fixes #264.

@ksooo for review
@popcornmix @gkovacsp this should fix the issue you reported, can you test it?