### PR TITLE
Don't reconnect immediately on register error

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.0.2"
+  version="4.0.3"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.0.3
+- fixed unresponsiveness when wrong credentials are used
+
 4.0.2
 - updated build instructions in the README
 - fixed Travis CI and AppVeyor automated builds

--- a/src/HTSPConnection.cpp
+++ b/src/HTSPConnection.cpp
@@ -567,7 +567,11 @@ void CHTSPConnection::Register ( void )
 
 fail:
   if (!m_suspended)
+  {
+    /* Don't immediately reconnect (spare server CPU cycles)*/
+    Sleep(SLOW_RECONNECT_INTERVAL);
     Disconnect();
+  }
 }
 
 /*

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -74,6 +74,7 @@ extern "C" {
                                            // actual server HTSP version matches (runtime htsp version check).
 #define FAST_RECONNECT_ATTEMPTS     (5)
 #define FAST_RECONNECT_INTERVAL   (500) // ms
+#define SLOW_RECONNECT_INTERVAL  (5000) // ms
 #define UNNUMBERED_CHANNEL      (10000)
 #define INVALID_SEEKTIME           (-1)
 


### PR DESCRIPTION
The problem: when credentials are wrongly entered or when there is a htsp version mismatch, an immediately reconnect will be issued. This will most likely fail again without user action and will cause a fast running reconnect loop. Tvheadend will be unresponsive as it's quite busy with processing all these connect request. The machine might feel frozen to the end user.

Watch the time-stamps here.

`2017-01-06 21:47:47.737 [   INFO] htsp: Got connection from 127.0.0.1
2017-01-06 21:47:47.738 [   INFO] htsp: 127.0.0.1: Welcomed client software: Kodi Media Center (HTSPv25)
2017-01-06 21:47:47.738 [   INFO] htsp: 127.0.0.1 [ Kodi Media Center ]: Unauthorized access
2017-01-06 21:47:47.738 [   INFO] htsp: 127.0.0.1 [ Kodi Media Center ]: Disconnected
2017-01-06 21:47:47.739 [   INFO] htsp: Got connection from 127.0.0.1
2017-01-06 21:47:47.746 [   INFO] htsp: 127.0.0.1: Welcomed client software: Kodi Media Center (HTSPv25)
2017-01-06 21:47:47.747 [   INFO] htsp: 127.0.0.1 [ Kodi Media Center ]: Unauthorized access
2017-01-06 21:47:47.747 [   INFO] htsp: 127.0.0.1 [ Kodi Media Center ]: Disconnected
2017-01-06 21:47:47.747 [   INFO] htsp: Got connection from 127.0.0.1
2017-01-06 21:47:47.747 [   INFO] htsp: 127.0.0.1: Welcomed client software: Kodi Media Center (HTSPv25)
2017-01-06 21:47:47.747 [   INFO] htsp: 127.0.0.1 [ Kodi Media Center ]: Unauthorized access
2017-01-06 21:47:47.747 [   INFO] htsp: 127.0.0.1 [ Kodi Media Center ]: Disconnected`

The solution:
Delay the reconnect.

@ksooo @Jalle19 
