### PR TITLE
3.4.21: Fix timeshift state and data calculation if demuxer is not active

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="3.4.20"
+  version="3.4.21"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,15 @@
+3.4.21
+- fixed: timeshift state and data calculation if demuxer is not active (e.g. when playing a recording)
+
+3.4.20
+- updated language files from Transifex
+
+3.4.19
+- updated language files from Transifex
+
+3.4.18
+- updated language files from Transifex
+
 3.4.17
 - fixed: duplicate 'prevent duplicate episodes' timer settings values
 

--- a/src/HTSPDemuxer.cpp
+++ b/src/HTSPDemuxer.cpp
@@ -108,6 +108,7 @@ void CHTSPDemuxer::Close ( void )
 {
   CLockObject lock(m_conn.Mutex());
   Close0();
+  ResetStatus();
   Logger::Log(LogLevel::LEVEL_DEBUG, "demux close");
 }
 
@@ -151,6 +152,7 @@ void CHTSPDemuxer::Abort ( void )
   Logger::Log(LogLevel::LEVEL_TRACE, "demux abort");
   CLockObject lock(m_conn.Mutex());
   Abort0();
+  ResetStatus();
 }
 
 bool CHTSPDemuxer::Seek 
@@ -268,6 +270,9 @@ int64_t CHTSPDemuxer::GetTimeshiftBufferEnd() const
 
 bool CHTSPDemuxer::IsTimeShifting() const
 {
+  if (!m_subscription.IsActive())
+    return false;
+
   if (m_subscription.GetSpeed() != SPEED_NORMAL)
     return true;
 
@@ -304,6 +309,9 @@ void CHTSPDemuxer::SetStreamingProfile(const std::string &profile)
 
 bool CHTSPDemuxer::IsRealTimeStream() const
 {
+  if (!m_subscription.IsActive())
+    return false;
+
   /* Avoid using the getters since they lock individually and
    * we want the calculation to be consistent */
   CLockObject lock(m_mutex);
@@ -318,6 +326,7 @@ void CHTSPDemuxer::ResetStatus()
 
   m_signalInfo.Clear();
   m_sourceInfo.Clear();
+  m_timeshiftStatus.Clear();
 }
 
 /* **************************************************************************

--- a/src/tvheadend/status/TimeshiftStatus.h
+++ b/src/tvheadend/status/TimeshiftStatus.h
@@ -54,12 +54,20 @@ namespace tvheadend
       /**
        * Constructor
        */
-      TimeshiftStatus() :
-          full(0),
-          shift(0),
-          start(0),
-          end(0)
+      TimeshiftStatus()
       {
+        Clear();
+      }
+
+      /**
+       * Clears the current status
+       */
+      void Clear()
+      {
+        full = false;
+        shift = 0;
+        start = 0;;
+        end = 0;
       }
     };
   }


### PR DESCRIPTION
Backport of #293 

This should fix #292

I runtime tested this on macOS, latest kodi master.

@Jalle19 mind doing the review.