### PR TITLE
Add support for genre to recordings.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.0.15"
+  version="4.0.16"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>
@@ -183,7 +183,7 @@
     <disclaimer lang="vi_VN">Đây là phần mềm không ổn định! Các tác giả không chịu trách nhiệm đối với bản ghi âm thất bại, giờ không chính xác, giờ lãng phí, hoặc bất kỳ tác dụng không mong muốn khác..</disclaimer>
     <disclaimer lang="zh_CN">这是不稳定版的软件！作者不对录像失败、错误定时造成时间浪费或其它不良影响负责。</disclaimer>
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
-    <news>Added support for 'default' recording priority setting value</news>
+    <news>Added support for genre to recordings</news>
     <platform>@PLATFORM@</platform>
   </extension>
 </addon>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.0.16
+- Added support for genre to recordings
+
 4.0.15
 - Added support for 'default' recording priority setting value
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1273,8 +1273,8 @@ void CTvheadend::CreateEvent
   epg.iYear               = 0;    /* not supported by tvh */
   epg.strIMDBNumber       = NULL; /* not supported by tvh */
   epg.strIconPath         = event.GetImage().c_str();
-  epg.iGenreType          = event.GetContent() & 0xF0;
-  epg.iGenreSubType       = event.GetContent() & 0x0F;
+  epg.iGenreType          = event.GetGenreType();
+  epg.iGenreSubType       = event.GetGenreSubType();
   epg.strGenreDescription = NULL; /* not supported by tvh */
   epg.firstAired          = event.GetAired();
   epg.iParentalRating     = event.GetAge();

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -442,6 +442,10 @@ PVR_ERROR CTvheadend::GetRecordings ( ADDON_HANDLE handle )
       /* Description */
       strncpy(rec.strPlot, recording.GetDescription().c_str(), sizeof(rec.strPlot) - 1);
 
+      /* Genre */
+      rec.iGenreType = recording.GetGenreType();
+      rec.iGenreSubType = recording.GetGenreSubType();
+
       /* Time/Duration */
       rec.recordingTime = (time_t)recording.GetStart();
       rec.iDuration = static_cast<int>(recording.GetStop() - recording.GetStart());
@@ -1936,7 +1940,7 @@ void CTvheadend::ParseChannelDelete ( htsmsg_t *msg )
 void CTvheadend::ParseRecordingAddOrUpdate ( htsmsg_t *msg, bool bAdd )
 {
   const char *state, *str;
-  uint32_t id, channel, eventId, retention, removal, priority, enabled, playCount, playPosition;
+  uint32_t id, channel, eventId, retention, removal, priority, enabled, contentType, playCount, playPosition;
   int64_t start, stop, startExtra, stopExtra;
 
   /* Channels must be complete */
@@ -2126,6 +2130,8 @@ void CTvheadend::ParseRecordingAddOrUpdate ( htsmsg_t *msg, bool bAdd )
   // TODO: What?
   else if ((str = htsmsg_get_str(msg, "summary")) != NULL)
     rec.SetDescription(str);
+  if (!htsmsg_get_u32(msg, "contentType", &contentType))
+    rec.SetContentType(contentType);
   if ((str = htsmsg_get_str(msg, "timerecId")) != NULL)
     rec.SetTimerecId(str);
   if ((str = htsmsg_get_str(msg, "autorecId")) != NULL)

--- a/src/tvheadend/entity/Event.h
+++ b/src/tvheadend/entity/Event.h
@@ -91,6 +91,8 @@ namespace tvheadend
 
       uint32_t GetContent() const { return m_content; }
       void SetContent(uint32_t content) { m_content = content; }
+      uint32_t GetGenreType() const { return m_content & 0xF0; }
+      uint32_t GetGenreSubType() const { return m_content & 0x0F; }
 
       time_t GetStart() const { return m_start; }
       void SetStart(time_t start) { m_start = start; }

--- a/src/tvheadend/entity/Recording.h
+++ b/src/tvheadend/entity/Recording.h
@@ -65,7 +65,8 @@ namespace tvheadend
         m_lifetime(0),
         m_priority(50),   // Kodi default - "normal"
         m_playCount(0),
-        m_playPosition(0)
+        m_playPosition(0),
+        m_contentType(0)
       {
       }
 
@@ -91,7 +92,8 @@ namespace tvheadend
                m_lifetime == other.m_lifetime &&
                m_priority == other.m_priority &&
                m_playCount == other.m_playCount &&
-               m_playPosition == other.m_playPosition;
+               m_playPosition == other.m_playPosition &&
+               m_contentType == other.m_contentType;
       }
 
       bool operator!=(const Recording &other) const
@@ -197,6 +199,13 @@ namespace tvheadend
       uint32_t GetPlayPosition() const { return m_playPosition; }
       void SetPlayPosition(uint32_t playPosition) { m_playPosition = playPosition; }
 
+      void SetContentType(uint32_t content) { m_contentType = content; }
+      uint32_t GetContentType() const { return m_contentType; }
+      // tvh returns only the major DVB category for recordings in the
+      // bottom four bits and no sub-category
+      uint32_t GetGenreType() const { return m_contentType * 0x10; }
+      uint32_t GetGenreSubType() const { return 0; }
+
     private:
       uint32_t         m_enabled;
       uint32_t         m_channel;
@@ -219,6 +228,7 @@ namespace tvheadend
       uint32_t         m_priority;
       uint32_t         m_playCount;
       uint32_t         m_playPosition;
+      uint32_t         m_contentType;
     };
   }
 }


### PR DESCRIPTION
Genre is available via HTSP since "ever", but it seems we forgot to implement it.

Strange thing is that for epg events both major catagories and sub categories are delivered by tvh, but for recordings only the major category, although a quick look at the tvh code reveals that it should be very easy to support sub categories also for recordings (@Glenn-1990 maybe something for you to add to tvh? htsp version bump required!)