### PR TITLE
PVR API 5.6.0

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.1.2"
+  version="4.1.3"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>
@@ -183,7 +183,7 @@
     <disclaimer lang="vi_VN">Đây là phần mềm không ổn định! Các tác giả không chịu trách nhiệm đối với bản ghi âm thất bại, giờ không chính xác, giờ lãng phí, hoặc bất kỳ tác dụng không mong muốn khác..</disclaimer>
     <disclaimer lang="zh_CN">这是不稳定版的软件！作者不对录像失败、错误定时造成时间浪费或其它不良影响负责。</disclaimer>
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
-    <news>Implemented PVR API v5.5.0</news>
+    <news>Implemented PVR API v5.6.0</news>
     <platform>@PLATFORM@</platform>
   </extension>
 </addon>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,8 @@
+4.1.3
+- PVR API v5.6.0: Drop GetLiveStreamURL
+- PVR API v5.6.0: Drop PVR_RECORDING::strStreamURL
+- PVR API v5.6.0: Add implementation for GetChannelStreamProperties and GetRecordingStreamProperties
+
 4.1.2
 - PVR API v5.5.0: Add series link support
 - PVR API v5.5.0: Drop GetChannelSwitchDelay

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -536,28 +536,32 @@ PVR_ERROR OpenDialogChannelScan(void)
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
+
 PVR_ERROR DeleteChannel(const PVR_CHANNEL &_unused(channel))
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
+
 PVR_ERROR RenameChannel(const PVR_CHANNEL &_unused(channel))
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
+
 PVR_ERROR MoveChannel(const PVR_CHANNEL &_unused(channel))
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
+
 PVR_ERROR OpenDialogChannelSettings(const PVR_CHANNEL &_unused(channel))
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
+
 PVR_ERROR OpenDialogChannelAdd(const PVR_CHANNEL &_unused(channel))
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
 
-/* Timeshift?? - not sure if we can use these? */
 void PauseStream(bool _unused(bPaused))
 {
 }
@@ -568,25 +572,36 @@ int ReadLiveStream
 {
   return 0;
 }
+
 long long SeekLiveStream
   (long long _unused(iPosition), int _unused(iWhence))
 {
   return -1;
 }
+
 long long PositionLiveStream(void)
 {
   return -1;
 }
+
 long long LengthLiveStream(void)
 {
   return -1;
 }
-const char * GetLiveStreamURL(const PVR_CHANNEL &_unused(channel))
-{
-  return "";
-}
-PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *times)
+
+PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES*)
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
+
+PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL*, PVR_NAMED_VALUE*, unsigned int*)
+{
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
+PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING*, PVR_NAMED_VALUE*, unsigned int*)
+{
+  return PVR_ERROR_NOT_IMPLEMENTED;
+}
+
 } /* extern "C" */


### PR DESCRIPTION
- Remove GetLiveStreamURL. 
- Remove PVR_RECORDING::strStreamURL. 
- Add GetChannelStreamProperties. 
- Add GetRecordingStreamProperties.

https://github.com/xbmc/xbmc/pull/12660