### PR TITLE
3.4.27: Add support for 'default' recording priority setting value.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="3.4.26"
+  version="3.4.27"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>
@@ -188,6 +188,7 @@
     <disclaimer lang="vi_VN">Đây là phần mềm không ổn định! Các tác giả không chịu trách nhiệm đối với bản ghi âm thất bại, giờ không chính xác, giờ lãng phí, hoặc bất kỳ tác dụng không mong muốn khác..</disclaimer>
     <disclaimer lang="zh_CN">这是不稳定版的软件！作者不对录像失败、错误定时造成时间浪费或其它不良影响负责。</disclaimer>
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
+    <news>Added support for 'default' recording priority setting value</news>
     <platform>@PLATFORM@</platform>
   </extension>
 </addon>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,22 @@
+3.4.27
+- Added support for 'default' recording priority setting value
+  (fixes tvh 4.3 incompatibility with recordings not appearing in Kodi)
+
+3.4.26
+- updated language files from Transifex
+
+3.4.25
+- updated language files from Transifex
+
+3.4.24
+- updated language files from Transifex
+
+3.4.23
+- updated language files from Transifex
+
+3.4.22
+- updated language files from Transifex
+
 3.4.21
 - fixed: timeshift state and data calculation if demuxer is not active (e.g. when playing a recording)
 

--- a/pvr.hts/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hts/resources/language/resource.language.en_gb/strings.po
@@ -236,7 +236,13 @@ msgctxt "#30367"
 msgid "This rule only: Record max once per day"
 msgstr ""
 
-#empty strings from id 30368 to 30372
+#. Recording priority representation
+#: src/Tvheadend.cpp
+msgctxt "#30368"
+msgid "Default"
+msgstr ""
+
+#empty strings from id 30369 to 30372
 
 #. Recording lifetime representation
 #: src/Tvheadend.cpp

--- a/src/HTSPTypes.h
+++ b/src/HTSPTypes.h
@@ -35,7 +35,8 @@ typedef enum {
   DVR_PRIO_NORMAL      = 2,
   DVR_PRIO_LOW         = 3,
   DVR_PRIO_UNIMPORTANT = 4,
-  DVR_PRIO_NOT_SET     = 5
+  DVR_PRIO_NOT_SET     = 5,
+  DVR_PRIO_DEFAULT     = 6
 } dvr_prio_t;
 
 typedef enum {

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -656,6 +656,7 @@ PVR_ERROR CTvheadend::GetTimerTypes ( PVR_TIMER_TYPE types[], int *size )
   static std::vector< std::pair<int, std::string> > priorityValues;
   if (priorityValues.size() == 0)
   {
+    priorityValues.push_back(std::make_pair(DVR_PRIO_DEFAULT,     XBMC->GetLocalizedString(30368)));
     priorityValues.push_back(std::make_pair(DVR_PRIO_UNIMPORTANT, XBMC->GetLocalizedString(30355)));
     priorityValues.push_back(std::make_pair(DVR_PRIO_LOW,         XBMC->GetLocalizedString(30354)));
     priorityValues.push_back(std::make_pair(DVR_PRIO_NORMAL,      XBMC->GetLocalizedString(30353)));
@@ -2046,6 +2047,7 @@ void CTvheadend::ParseRecordingAddOrUpdate ( htsmsg_t *msg, bool bAdd )
       case DVR_PRIO_NORMAL:
       case DVR_PRIO_LOW:
       case DVR_PRIO_UNIMPORTANT:
+      case DVR_PRIO_DEFAULT:
         rec.SetPriority(priority);
         break;
       default:

--- a/src/tvheadend/Settings.h
+++ b/src/tvheadend/Settings.h
@@ -50,7 +50,7 @@ namespace tvheadend {
     static const int         DEFAULT_AUTOREC_MAXDIFF; // mins. Maximum difference between real and approximate start time for auto recordings
     static const int         DEFAULT_APPROX_TIME;     // 0..1 (0 = use a fixed start time, 1 = use an approximate start time for auto recordings)
     static const std::string DEFAULT_STREAMING_PROFILE;
-    static const int         DEFAULT_DVR_PRIO;        // 0..4  (0 = max, 4 = min)
+    static const int         DEFAULT_DVR_PRIO;        // any dvr_prio_t numeric value
     static const int         DEFAULT_DVR_LIFETIME;    // 0..14 (0 = 1 day, 14 = forever)
     static const int         DEFAULT_DVR_DUBDETECT;   // 0..5  (0 = record all, 5 = limit to once a day)
 


### PR DESCRIPTION
Fixes tvh 4.3 incompatibility with recordings not appearing in Kodi. Reported 'a hundred times' in different forums.

Krypton backport of #313

@Jalle19 mind taking a look.