### PR TITLE
Feature/refactor settings remove singleton

### DIFF
--- a/src/AutoRecordings.cpp
+++ b/src/AutoRecordings.cpp
@@ -242,7 +242,7 @@ PVR_ERROR AutoRecordings::SendAutorecAddOrUpdate(const PVR_TIMER &timer, bool up
   /*                                                                                        */
   /* bAutorecApproxTime disabled: => start time in kodi = begin of starting window in tvh   */
   /*                              => end time in kodi   = end of starting window in tvh     */
-  const Settings &settings = Settings::GetInstance();
+  const Settings &settings = tvh->GetSettings();
 
   if (settings.GetAutorecApproxTime())
   {

--- a/src/HTSPDemuxer.cpp
+++ b/src/HTSPDemuxer.cpp
@@ -91,7 +91,7 @@ bool CHTSPDemuxer::Open ( uint32_t channelId, enum eSubscriptionWeight weight )
 
   /* Open new subscription */
   m_subscription.SendSubscribe(channelId, weight);
-  
+
   /* Reset status */
   ResetStatus();
 
@@ -100,7 +100,7 @@ bool CHTSPDemuxer::Open ( uint32_t channelId, enum eSubscriptionWeight weight )
     m_subscription.SendUnsubscribe();
   else
     m_lastUse.store(time(nullptr));
-  
+
   return m_subscription.IsActive();
 }
 
@@ -123,7 +123,7 @@ DemuxPacket *CHTSPDemuxer::Read ( void )
     return pkt;
   }
   Logger::Log(LogLevel::LEVEL_TRACE, "demux read nothing");
-  
+
   return PVR->AllocateDemuxPacket(0);
 }
 
@@ -155,7 +155,7 @@ void CHTSPDemuxer::Abort ( void )
   ResetStatus();
 }
 
-bool CHTSPDemuxer::Seek 
+bool CHTSPDemuxer::Seek
   ( double time, bool _unused(backwards), double *startpts )
 {
   if (!m_subscription.IsActive())
@@ -171,14 +171,14 @@ bool CHTSPDemuxer::Seek
   /* Wait for time */
   CLockObject lock(m_conn.Mutex());
 
-  if (!m_seekCond.Wait(m_conn.Mutex(), m_seekTime, Settings::GetInstance().GetResponseTimeout()))
+  if (!m_seekCond.Wait(m_conn.Mutex(), m_seekTime, tvh->GetSettings().GetResponseTimeout()))
   {
     Logger::Log(LogLevel::LEVEL_ERROR, "failed to get subscriptionSeek response");
     m_seeking = false;
     Flush(); /* try to resync */
     return false;
   }
-  
+
   m_seeking = false;
   if (m_seekTime == INVALID_SEEKTIME)
     return false;
@@ -225,7 +225,7 @@ PVR_ERROR CHTSPDemuxer::CurrentStreams ( PVR_STREAM_PROPERTIES *props )
 PVR_ERROR CHTSPDemuxer::CurrentSignal ( PVR_SIGNAL_STATUS &sig )
 {
   CLockObject lock(m_mutex);
-  
+
   memset(&sig, 0, sizeof(sig));
 
   strncpy(sig.strAdapterName,   m_sourceInfo.si_adapter.c_str(),
@@ -238,7 +238,7 @@ PVR_ERROR CHTSPDemuxer::CurrentSignal ( PVR_SIGNAL_STATUS &sig )
           sizeof(sig.strProviderName) - 1);
   strncpy(sig.strMuxName,       m_sourceInfo.si_mux.c_str(),
           sizeof(sig.strMuxName) - 1);
-  
+
   sig.iSNR      = m_signalInfo.fe_snr;
   sig.iSignal   = m_signalInfo.fe_signal;
   sig.iBER      = m_signalInfo.fe_ber;
@@ -337,7 +337,7 @@ bool CHTSPDemuxer::IsRealTimeStream() const
    * we want the calculation to be consistent */
   CLockObject lock(m_mutex);
 
-  /* Handle as real time when reading close to the EOF (10000000µs - 10s) */
+  /* Handle as real time when reading close to the EOF (10000000ï¿½s - 10s) */
   return (m_timeshiftStatus.shift < 10000000);
 }
 
@@ -396,14 +396,14 @@ void CHTSPDemuxer::ParseMuxPacket ( htsmsg_t *m )
   DemuxPacket *pkt;
   char        _unused(type) = 0;
   int         ignore;
-  
+
   /* Ignore packets while switching channels */
   if (!m_subscription.IsActive())
   {
     Logger::Log(LogLevel::LEVEL_DEBUG, "Ignored mux packet due to channel switch");
     return;
   }
-  
+
   /* Validate fields */
   if (htsmsg_get_u32(m, "stream", &idx) ||
       htsmsg_get_bin(m, "payload", &bin, &binlen))
@@ -432,7 +432,7 @@ void CHTSPDemuxer::ParseMuxPacket ( htsmsg_t *m )
   /* Duration */
   if (!htsmsg_get_u32(m, "duration", &u32))
     pkt->duration = TVH_TO_DVD_TIME(u32);
-  
+
   /* Timestamps */
   if (!htsmsg_get_s64(m, "dts", &s64))
     pkt->dts      = TVH_TO_DVD_TIME(s64);
@@ -498,7 +498,7 @@ void CHTSPDemuxer::ParseSubscriptionStart ( htsmsg_t *m )
     PVR_STREAM_PROPERTIES::PVR_STREAM stream = {};
 
     Logger::Log(LogLevel::LEVEL_DEBUG, "demux subscription start");
-    
+
     CodecDescriptor codecDescriptor = CodecDescriptor::GetCodecByName(type);
     xbmc_codec_t codec = codecDescriptor.Codec();
 
@@ -523,7 +523,7 @@ void CHTSPDemuxer::ParseSubscriptionStart ( htsmsg_t *m )
           stream.iCodecType == XBMC_CODEC_TYPE_AUDIO)
       {
         const char *language;
-        
+
         if ((language = htsmsg_get_str(&f->hmf_msg, "language")) != NULL)
           strncpy(stream.strLanguage, language, sizeof(stream.strLanguage) - 1);
       }
@@ -540,19 +540,19 @@ void CHTSPDemuxer::ParseSubscriptionStart ( htsmsg_t *m )
       {
         stream.iWidth  = htsmsg_get_u32_or_default(&f->hmf_msg, "width", 0);
         stream.iHeight = htsmsg_get_u32_or_default(&f->hmf_msg, "height", 0);
-        
-        /* Ignore this message if the stream details haven't been determined 
-           yet, a new message will be sent once they have. This is fixed in 
+
+        /* Ignore this message if the stream details haven't been determined
+           yet, a new message will be sent once they have. This is fixed in
            some versions of tvheadend and is here for backward compatibility. */
         if (stream.iWidth == 0 || stream.iHeight == 0)
         {
           Logger::Log(LogLevel::LEVEL_DEBUG, "Ignoring subscriptionStart, stream details missing");
           return;
         }
-        
+
         /* Setting aspect ratio to zero will cause XBMC to handle changes in it */
         stream.fAspect = 0.0f;
-        
+
         if ((u32 = htsmsg_get_u32_or_default(&f->hmf_msg, "duration", 0)) > 0)
         {
           stream.iFPSScale = u32;
@@ -587,7 +587,7 @@ void CHTSPDemuxer::ParseSubscriptionStart ( htsmsg_t *m )
 void CHTSPDemuxer::ParseSourceInfo ( htsmsg_t *m )
 {
   const char *str;
-  
+
   /* Ignore */
   if (!m) return;
 

--- a/src/HTSPVFS.cpp
+++ b/src/HTSPVFS.cpp
@@ -206,7 +206,7 @@ void CHTSPVFS::SendFileClose ( void )
 
   /* If setting set, we will increase play count with CTvheadend::SetPlayCount */
   if (m_conn.GetProtocol() >= 27)
-    htsmsg_add_u32(m, "playcount", Settings::GetInstance().GetDvrPlayStatus() ?
+    htsmsg_add_u32(m, "playcount", tvh->GetSettings().GetDvrPlayStatus() ?
         HTSP_DVR_PLAYCOUNT_KEEP : HTSP_DVR_PLAYCOUNT_INCR);
 
   Logger::Log(LogLevel::LEVEL_DEBUG, "vfs close id=%d", m_fileId);

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -69,6 +69,12 @@ void CTvheadend::Start ( void )
  * Miscellaneous
  * *************************************************************************/
 
+void CTvheadend::SetSettings(tvheadend::Settings *settings)
+{
+  CLockObject lock(m_mutex);
+  m_settings = settings;
+}
+
 PVR_ERROR CTvheadend::GetDriveSpace ( long long *total, long long *used )
 {
   int64_t s64;

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -804,6 +804,10 @@ PVR_ERROR CTvheadend::GetTimerTypes ( PVR_TIMER_TYPE types[], int *size )
       PVR_TIMER_TYPE_SUPPORTS_PRIORITY          |
       PVR_TIMER_TYPE_SUPPORTS_LIFETIME;
 
+  int dvrPriority = m_settings.GetDvrPriority();
+  int dvrDupDetect = m_settings.GetDvrDupdetect();
+  int dvrLifetime = m_settings.GetDvrLifetime();
+
   if (m_conn.GetProtocol() >= 23)
   {
     TIMER_ONCE_MANUAL_ATTRIBS |= PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE;
@@ -822,9 +826,9 @@ PVR_ERROR CTvheadend::GetTimerTypes ( PVR_TIMER_TYPE types[], int *size )
       TIMER_ONCE_MANUAL_ATTRIBS,
       /* Let Kodi generate the description. */
       "",
-      m_settings.GetDvrPriority(),
-      m_settings.GetDvrDupdetect(),
-      m_settings.GetDvrLifetime(),
+      dvrPriority,
+      dvrDupDetect,
+      dvrLifetime,
       /* Values definitions for priorities. */
       priorityValues,
       /* Values definitions for lifetime. */
@@ -839,9 +843,9 @@ PVR_ERROR CTvheadend::GetTimerTypes ( PVR_TIMER_TYPE types[], int *size )
       TIMER_ONCE_EPG_ATTRIBS,
       /* Let Kodi generate the description. */
       "",
-      m_settings.GetDvrPriority(),
-      m_settings.GetDvrDupdetect(),
-      m_settings.GetDvrLifetime(),
+      dvrPriority,
+      dvrDupDetect,
+      dvrLifetime,
       /* Values definitions for priorities. */
       priorityValues,
       /* Values definitions for lifetime. */
@@ -859,9 +863,9 @@ PVR_ERROR CTvheadend::GetTimerTypes ( PVR_TIMER_TYPE types[], int *size )
       /* Description. */
       XBMC->GetLocalizedString(30350), // "One Time (Scheduled by timer rule)"
       /* Values definitions for priorities. */
-      m_settings.GetDvrPriority(),
-      m_settings.GetDvrDupdetect(),
-      m_settings.GetDvrLifetime(),
+      dvrPriority,
+      dvrDupDetect,
+      dvrLifetime,
       /* Values definitions for priorities. */
       priorityValues,
       /* Values definitions for lifetime. */
@@ -878,9 +882,9 @@ PVR_ERROR CTvheadend::GetTimerTypes ( PVR_TIMER_TYPE types[], int *size )
       PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES,
       /* Description. */
       XBMC->GetLocalizedString(30350), // "One Time (Scheduled by timer rule)"
-      m_settings.GetDvrPriority(),
-      m_settings.GetDvrDupdetect(),
-      m_settings.GetDvrLifetime(),
+      dvrPriority,
+      dvrDupDetect,
+      dvrLifetime,
       /* Values definitions for priorities. */
       priorityValues,
       /* Values definitions for lifetime. */
@@ -904,9 +908,9 @@ PVR_ERROR CTvheadend::GetTimerTypes ( PVR_TIMER_TYPE types[], int *size )
       PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS,
       /* Let Kodi generate the description. */
       "",
-      m_settings.GetDvrPriority(),
-      m_settings.GetDvrDupdetect(),
-      m_settings.GetDvrLifetime(),
+      dvrPriority,
+      dvrDupDetect,
+      dvrLifetime,
       /* Values definitions for priorities. */
       priorityValues,
       /* Values definitions for lifetime. */
@@ -944,9 +948,9 @@ PVR_ERROR CTvheadend::GetTimerTypes ( PVR_TIMER_TYPE types[], int *size )
         TIMER_REPEATING_SERIESLINK_ATTRIBS,
         /* Description. */
         XBMC->GetLocalizedString(30369), // "Timer rule (series link)"
-        m_settings.GetDvrPriority(),
-        m_settings.GetDvrDupdetect(),
-        m_settings.GetDvrLifetime(),
+        dvrPriority,
+        dvrDupDetect,
+        dvrLifetime,
         /* Values definitions for priorities. */
         priorityValues,
         /* Values definitions for lifetime. */
@@ -989,9 +993,9 @@ PVR_ERROR CTvheadend::GetTimerTypes ( PVR_TIMER_TYPE types[], int *size )
       TIMER_REPEATING_EPG_ATTRIBS,
       /* Let Kodi generate the description. */
       "",
-      m_settings.GetDvrPriority(),
-      m_settings.GetDvrDupdetect(),
-      m_settings.GetDvrLifetime(),
+      dvrPriority,
+      dvrDupDetect,
+      dvrLifetime,
       /* Values definitions for priorities. */
       priorityValues,
       /* Values definitions for lifetime. */

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -394,6 +394,8 @@ public:
     return m_settings;
   }
 
+  void SetSettings(tvheadend::Settings *settings);
+
   void GetLivetimeValues(std::vector<std::pair<int, std::string>>& lifetimeValues) const;
 
 private:

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -155,7 +155,7 @@ class CHTSPRegister
 public:
   CHTSPRegister ( CHTSPConnection *conn );
   ~CHTSPRegister ();
- 
+
 private:
   CHTSPConnection *m_conn;
   void *Process ( void );
@@ -176,7 +176,7 @@ public:
   void Start       ( void );
   void Stop        ( void );
   void Disconnect  ( void );
-  
+
   bool      SendMessage0    ( const char *method, htsmsg_t *m );
   htsmsg_t *SendAndWait0    ( const char *method, htsmsg_t *m, int iResponseTimeout = -1);
   htsmsg_t *SendAndWait     ( const char *method, htsmsg_t *m, int iResponseTimeout = -1 );
@@ -188,14 +188,14 @@ public:
   std::string GetServerName    ( void ) const;
   std::string GetServerVersion ( void ) const;
   std::string GetServerString  ( void ) const;
-  
+
   bool        HasCapability(const std::string &capability) const;
 
   inline P8PLATFORM::CMutex& Mutex ( void ) { return m_mutex; }
 
   void        OnSleep ( void );
   void        OnWake  ( void );
-  
+
 private:
   void*       Process          ( void );
   void        Register         ( void );
@@ -271,7 +271,7 @@ private:
   tvheadend::status::DescrambleInfo       m_descrambleInfo;
   tvheadend::Subscription                 m_subscription;
   std::atomic<time_t>                     m_lastUse;
-  
+
   void         Close0         ( void );
   void         Abort0         ( void );
   bool         Open           ( uint32_t channelId,
@@ -292,7 +292,7 @@ private:
    * Resets the signal and quality info
    */
   void ResetStatus();
-  
+
   void ParseMuxPacket           ( htsmsg_t *m );
   void ParseSourceInfo          ( htsmsg_t *m );
   void ParseSubscriptionStart   ( htsmsg_t *m );
@@ -308,7 +308,7 @@ private:
 /*
  * HTSP VFS - recordings
  */
-class CHTSPVFS 
+class CHTSPVFS
 {
   friend class CTvheadend;
 
@@ -344,7 +344,7 @@ class CTvheadend
   : public P8PLATFORM::CThread
 {
 public:
-  CTvheadend(PVR_PROPERTIES *pvrProps);
+  CTvheadend(PVR_PROPERTIES *pvrProps, tvheadend::Settings *settings);
   ~CTvheadend();
 
   void Start ( void );
@@ -388,6 +388,11 @@ public:
   PVR_ERROR GetEPGForChannel  ( ADDON_HANDLE handle, const PVR_CHANNEL &chn,
                                 time_t start, time_t end );
   PVR_ERROR SetEPGTimeFrame   ( int iDays );
+
+  tvheadend::Settings& GetSettings()
+  {
+    return m_settings;
+  }
 
   void GetLivetimeValues(std::vector<std::pair<int, std::string>>& lifetimeValues) const;
 
@@ -440,6 +445,8 @@ private:
   AutoRecordings              m_autoRecordings;
 
   int                         m_epgMaxDays;
+
+  tvheadend::Settings         m_settings;
 
   /*
    * Predictive tuning

--- a/src/tvheadend/Settings.cpp
+++ b/src/tvheadend/Settings.cpp
@@ -46,6 +46,11 @@ const int         Settings::DEFAULT_DVR_LIFETIME        = 8; // enum 8 = 3 month
 const int         Settings::DEFAULT_DVR_DUBDETECT       = DVR_AUTOREC_RECORD_ALL;
 const bool        Settings::DEFAULT_DVR_PLAYSTATUS      = true;
 
+bool Settings::ReadTraceDebug()
+{
+  return ReadBoolSetting("trace_debug", DEFAULT_TRACE_DEBUG)
+}
+
 void Settings::ReadSettings()
 {
   /* Connection */
@@ -60,7 +65,7 @@ void Settings::ReadSettings()
   SetResponseTimeout(ReadIntSetting("response_timeout", DEFAULT_RESPONSE_TIMEOUT / 1000) * 1000);
 
   /* Debug */
-  SetTraceDebug(ReadBoolSetting("trace_debug", DEFAULT_TRACE_DEBUG));
+  SetTraceDebug(ReadTraceDebug());
 
   /* Data Transfer */
   SetAsyncEpg(ReadBoolSetting("epg_async", DEFAULT_ASYNC_EPG));

--- a/src/tvheadend/Settings.h
+++ b/src/tvheadend/Settings.h
@@ -82,6 +82,10 @@ namespace tvheadend {
     void ReadSettings();
 
     /**
+     * Read just the trace debug setting to setup logging when starting
+     */
+    bool ReadTraceDebug();
+    /**
      * Set a value according to key definition in settings.xml
      */
     ADDON_STATUS SetSetting(const std::string &key, const void *value);

--- a/src/tvheadend/Settings.h
+++ b/src/tvheadend/Settings.h
@@ -34,6 +34,27 @@ namespace tvheadend {
   class Settings {
   public:
 
+    Settings()
+    : m_strHostname(DEFAULT_HOST),
+      m_iPortHTSP(DEFAULT_HTTP_PORT),
+      m_iPortHTTP(DEFAULT_HTSP_PORT),
+      m_strUsername(DEFAULT_USERNAME),
+      m_strPassword(DEFAULT_PASSWORD),
+      m_iConnectTimeout(DEFAULT_CONNECT_TIMEOUT),
+      m_iResponseTimeout(DEFAULT_RESPONSE_TIMEOUT),
+      m_bTraceDebug(DEFAULT_TRACE_DEBUG),
+      m_bAsyncEpg(DEFAULT_ASYNC_EPG),
+      m_bPretunerEnabled(DEFAULT_PRETUNER_ENABLED),
+      m_iTotalTuners(DEFAULT_TOTAL_TUNERS),
+      m_iPreTunerCloseDelay(DEFAULT_PRETUNER_CLOSEDELAY),
+      m_bAutorecApproxTime(DEFAULT_APPROX_TIME),
+      m_iAutorecMaxDiff(DEFAULT_AUTOREC_MAXDIFF),
+      m_strStreamingProfile(DEFAULT_STREAMING_PROFILE),
+      m_iDvrPriority(DEFAULT_DVR_PRIO),
+      m_iDvrLifetime(DEFAULT_DVR_LIFETIME),
+      m_iDvrDupdetect(DEFAULT_DVR_DUBDETECT),
+      m_bDvrPlayStatus(DEFAULT_DVR_PLAYSTATUS) {}
+
     // Default values.
     static const std::string DEFAULT_HOST;
     static const int         DEFAULT_HTTP_PORT;
@@ -54,15 +75,6 @@ namespace tvheadend {
     static const int         DEFAULT_DVR_LIFETIME;    // 0..14 (0 = 1 day, 14 = forever)
     static const int         DEFAULT_DVR_DUBDETECT;   // 0..5  (0 = record all, 5 = limit to once a day)
     static const bool        DEFAULT_DVR_PLAYSTATUS;
-
-    /**
-     * Singleton getter for the instance
-     */
-    static Settings& GetInstance()
-    {
-      static Settings settings;
-      return settings;
-    }
 
     /**
      * Read all settings defined in settings.xml
@@ -98,29 +110,8 @@ namespace tvheadend {
     bool        GetDvrPlayStatus() const { return m_bDvrPlayStatus; }
 
   private:
-    Settings()
-    : m_strHostname(DEFAULT_HOST),
-      m_iPortHTSP(DEFAULT_HTTP_PORT),
-      m_iPortHTTP(DEFAULT_HTSP_PORT),
-      m_strUsername(DEFAULT_USERNAME),
-      m_strPassword(DEFAULT_PASSWORD),
-      m_iConnectTimeout(DEFAULT_CONNECT_TIMEOUT),
-      m_iResponseTimeout(DEFAULT_RESPONSE_TIMEOUT),
-      m_bTraceDebug(DEFAULT_TRACE_DEBUG),
-      m_bAsyncEpg(DEFAULT_ASYNC_EPG),
-      m_bPretunerEnabled(DEFAULT_PRETUNER_ENABLED),
-      m_iTotalTuners(DEFAULT_TOTAL_TUNERS),
-      m_iPreTunerCloseDelay(DEFAULT_PRETUNER_CLOSEDELAY),
-      m_bAutorecApproxTime(DEFAULT_APPROX_TIME),
-      m_iAutorecMaxDiff(DEFAULT_AUTOREC_MAXDIFF),
-      m_strStreamingProfile(DEFAULT_STREAMING_PROFILE),
-      m_iDvrPriority(DEFAULT_DVR_PRIO),
-      m_iDvrLifetime(DEFAULT_DVR_LIFETIME),
-      m_iDvrDupdetect(DEFAULT_DVR_DUBDETECT),
-      m_bDvrPlayStatus(DEFAULT_DVR_PLAYSTATUS) {}
-
-    Settings(Settings const &) = delete;
-    void operator=(Settings const &) = delete;
+    // Settings(Settings const &) = delete;
+    // void operator=(Settings const &) = delete;
 
     /**
      * Setters

--- a/src/tvheadend/entity/AutoRecording.cpp
+++ b/src/tvheadend/entity/AutoRecording.cpp
@@ -57,7 +57,7 @@ bool AutoRecording::operator!=(const AutoRecording &right)
 
 time_t AutoRecording::GetStart() const
 {
-  if (Settings::GetInstance().GetAutorecApproxTime())
+  if (tvh->GetSettings().GetAutorecApproxTime())
   {
     /* Calculate the approximate start time from the starting window */
     if ((m_startWindowBegin == -1) ||
@@ -93,7 +93,7 @@ void AutoRecording::SetStartWindowBegin(int32_t start)
 
 time_t AutoRecording::GetStop() const
 {
-  if (Settings::GetInstance().GetAutorecApproxTime())
+  if (tvh->GetSettings().GetAutorecApproxTime())
   {
     /* Tvh doesn't have an approximate stop time => "any time" */
     return 0;


### PR DESCRIPTION
This PR refactors the settings logic to remove the singleton and instead add the settings object as a property of the CTvheadend object.  This allows the use of multiple pvr.hts clients within Kodi (which I know is a hack but is very useful for some people).  If Kodi ever allows multiple instances of the same PVR client this is also a step towards that.  In addition I believe that passing dependencies e.g. settings into the dependant class is better than relying on a global instance for the same.