### PR TITLE
Fix windows build (missing ssize_t type definition), take 2.

### DIFF
--- a/src/tvheadend/HTSPConnection.cpp
+++ b/src/tvheadend/HTSPConnection.cpp
@@ -23,11 +23,11 @@
 
 extern "C"
 {
-#include <sys/types.h>
 #include "libhts/htsmsg_binary.h"
 #include "libhts/sha1.h"
 }
 
+#include "p8-platform/os.h"
 #include "p8-platform/util/StringUtils.h"
 
 #include "../client.h"

--- a/src/tvheadend/HTSPVFS.h
+++ b/src/tvheadend/HTSPVFS.h
@@ -21,12 +21,9 @@
  *
  */
 
-extern "C"
-{
-#include <sys/types.h>
-}
-
 #include <string>
+
+#include "p8-platform/os.h"
 
 struct PVR_RECORDING;
 


### PR DESCRIPTION
Followup to #335, which did not solve the build problem.