### PR TITLE
4.2.7: Fixed predictive tuning.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.2.6"
+  version="4.2.7"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>
@@ -182,6 +182,6 @@
     <disclaimer lang="zh_CN">这是不稳定版的软件！作者不对录像失败、错误定时造成时间浪费或其它不良影响负责。</disclaimer>
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
-    <news>More code cleanup. Fixes. New autorec dedup types. New EPG tag attributes.</news>
+    <news>Fixed predictive tuning</news>
   </extension>
 </addon>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,5 +1,6 @@
 4.2.7
 - Fixed predictive tuning (was broken with removal of API function 'SwitchChannel')
+- Added support for subchannel numbers (ATSC) to predictive tuning
 
 4.2.6
 - More code cleanup

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.2.7
+- Fixed predictive tuning (was broken with removal of API function 'SwitchChannel')
+
 4.2.6
 - More code cleanup
 - Fixed deadlock that may have occured when switching channels

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -215,6 +215,8 @@ public:
   bool         DemuxIsTimeShifting() const;
   bool         DemuxIsRealTimeStream() const;
 
+  void CloseExpiredSubscriptions();
+
   /*
    * VFS (pass-thru)
    */

--- a/src/tvheadend/ChannelTuningPredictor.cpp
+++ b/src/tvheadend/ChannelTuningPredictor.cpp
@@ -47,7 +47,7 @@ void ChannelTuningPredictor::RemoveChannel(uint32_t channelId)
 
 ChannelPair ChannelTuningPredictor::MakeChannelPair(const entity::Channel &channel)
 {
-  return ChannelPair(channel.GetId(), channel.GetNum());
+  return ChannelPair(channel.GetId(), ChannelNumber(channel.GetNum(), channel.GetNumMinor()));
 }
 
 ChannelPairIterator ChannelTuningPredictor::GetIterator(uint32_t channelId) const
@@ -68,7 +68,7 @@ uint32_t ChannelTuningPredictor::PredictNextChannelId(uint32_t tuningFrom, uint3
   auto toIt = GetIterator(tuningTo);
 
   /* Determine the respective channel numbers as well as the first channel */
-  uint32_t firstNum = m_channels.cbegin()->second;
+  const ChannelNumber& firstNum = m_channels.cbegin()->second;
 
   /* Create an iterator for the predicted channel. If prediction succeeds,
    * it will point at the channel we should tune to */

--- a/src/tvheadend/ChannelTuningPredictor.h
+++ b/src/tvheadend/ChannelTuningPredictor.h
@@ -38,10 +38,41 @@ namespace tvheadend
     const uint32_t CHANNEL_ID_NONE = -1;
 
     /**
+     * Defines a channel number
+     */
+    class ChannelNumber
+    {
+    public:
+      ChannelNumber()
+      : m_channelNumber(0), m_subchannelNumber(0) {}
+
+      ChannelNumber(uint32_t channelNumber, uint32_t  subchannelNumber)
+      : m_channelNumber(channelNumber), m_subchannelNumber(subchannelNumber) {}
+
+      bool operator ==(const ChannelNumber &right) const
+      {
+        return (m_channelNumber == right.m_channelNumber &&
+                m_subchannelNumber == right.m_subchannelNumber);
+      }
+
+      bool operator <(const ChannelNumber &right) const
+      {
+        if (m_channelNumber == right.m_channelNumber)
+          return m_subchannelNumber < right.m_subchannelNumber;
+
+        return m_channelNumber < right.m_channelNumber;
+      }
+
+    private:
+      uint32_t m_channelNumber;
+      uint32_t m_subchannelNumber;
+    };
+
+    /**
      * Defines a single channel ID/number pair
      */
-    typedef std::pair<uint32_t, uint32_t> ChannelPair;
-    typedef std::set<predictivetune::ChannelPair>::const_iterator ChannelPairIterator;
+    typedef std::pair<uint32_t, ChannelNumber> ChannelPair;
+    typedef std::set<ChannelPair>::const_iterator ChannelPairIterator;
 
     /**
      * Sorter for channel pairs


### PR DESCRIPTION
It broke with removal of API function `SwitchChannel`, because the implementation was relying on playing channels will not be closed when switching to another channel. That changed for Leia.

Second commit adds support for subchannel numbers (ATSC) to predictive tuning.

I runtime-tested this fix on macOS, latest Kodi master.

@Jalle19 mind taking a look at the changed code.
@CvH fyi. 