### PR TITLE
Implement API function GetStreamTimes & PVR Addon API 5.8.0

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.2.8"
+  version="4.2.9"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>
@@ -182,6 +182,6 @@
     <disclaimer lang="zh_CN">这是不稳定版的软件！作者不对录像失败、错误定时造成时间浪费或其它不良影响负责。</disclaimer>
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
-    <news>Fixed predictive tuning</news>
+    <news>Implemented GetStreamTimes API function. Updated to PVR Addon API 5.8.0.</news>
   </extension>
 </addon>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,11 @@
+4.2.9
+- PVR API v5.5.0: Implemented GetStreamTimes
+- PVR API v5.8.0: Dropped GetPlayingTime, GetBufferTimeStart, GetBufferTimeEnd, PositionRecordedStream, PositionLiveStream, MoveChannel
+- PVR API v5.8.0: Added support for PVR_CHANNEL_GROUP_MEMBER::iSubChannelNumber
+
+4.2.8
+- updated language files from Transifex
+
 4.2.7
 - Fixed predictive tuning (was broken with removal of API function 'SwitchChannel')
 - Added support for subchannel numbers (ATSC) to predictive tuning

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -209,11 +209,9 @@ public:
   PVR_ERROR    DemuxCurrentStreams ( PVR_STREAM_PROPERTIES *streams );
   PVR_ERROR    DemuxCurrentSignal  ( PVR_SIGNAL_STATUS &sig );
   PVR_ERROR    DemuxCurrentDescramble( PVR_DESCRAMBLE_INFO *info);
-  int64_t      DemuxGetTimeshiftTime() const;
-  int64_t      DemuxGetTimeshiftBufferStart() const;
-  int64_t      DemuxGetTimeshiftBufferEnd() const;
   bool         DemuxIsTimeShifting() const;
   bool         DemuxIsRealTimeStream() const;
+  PVR_ERROR    DemuxGetStreamTimes(PVR_STREAM_TIMES *times) const;
 
   void CloseExpiredSubscriptions();
 
@@ -224,7 +222,6 @@ public:
   void VfsClose();
   ssize_t VfsRead(unsigned char *buf, unsigned int len);
   long long VfsSeek(long long position, int whence);
-  long long VfsTell();
   long long VfsSize();
 
   /**
@@ -258,4 +255,6 @@ public:
   tvheadend::AutoRecordings m_autoRecordings;
 
   int m_epgMaxDays;
+
+  bool m_playingLiveStream;
 };

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -262,31 +262,18 @@ bool CanSeekStream(void)
   return tvh->HasCapability("timeshift");
 }
 
+PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *times)
+{
+  if (!times)
+    return PVR_ERROR_INVALID_PARAMETERS;
+
+  // TODO: handle recordings
+  return tvh->DemuxGetStreamTimes(times);
+}
+
 bool IsTimeshifting(void)
 {
   return tvh->DemuxIsTimeShifting();
-}
-
-static time_t ConvertMusecsToTime(int64_t musecs)
-{
-  // tvheadend reports microseconds for timeshifting values,
-  // Kodi expects it to be an absolute UNIX timestamp
-  return time(NULL) - static_cast<time_t>(static_cast<double>(musecs / 1000000));
-}
-
-time_t GetPlayingTime()
-{
-  return ConvertMusecsToTime(tvh->DemuxGetTimeshiftTime());
-}
-
-time_t GetBufferTimeStart()
-{
-  return ConvertMusecsToTime(tvh->DemuxGetTimeshiftBufferStart());
-}
-
-time_t GetBufferTimeEnd()
-{
-  return ConvertMusecsToTime(tvh->DemuxGetTimeshiftBufferEnd());
 }
 
 bool IsRealTimeStream()
@@ -514,11 +501,6 @@ long long SeekRecordedStream(long long iPosition, int iWhence /* = SEEK_SET */)
   return tvh->VfsSeek(iPosition, iWhence);
 }
 
-long long PositionRecordedStream(void)
-{
-  return tvh->VfsTell();
-}
-
 long long LengthRecordedStream(void)
 {
   return tvh->VfsSize();
@@ -528,7 +510,6 @@ long long LengthRecordedStream(void)
  * Unused Functions
  * *************************************************************************/
 
-/* Channel Management */
 PVR_ERROR OpenDialogChannelScan(void)
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
@@ -540,11 +521,6 @@ PVR_ERROR DeleteChannel(const PVR_CHANNEL&)
 }
 
 PVR_ERROR RenameChannel(const PVR_CHANNEL&)
-{
-  return PVR_ERROR_NOT_IMPLEMENTED;
-}
-
-PVR_ERROR MoveChannel(const PVR_CHANNEL&)
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
@@ -563,7 +539,6 @@ void PauseStream(bool)
 {
 }
 
-/* Live stream (VFS interface - not relevant) */
 int ReadLiveStream(unsigned char *, unsigned int)
 {
   return 0;
@@ -574,19 +549,9 @@ long long SeekLiveStream(long long, int)
   return -1;
 }
 
-long long PositionLiveStream(void)
-{
-  return -1;
-}
-
 long long LengthLiveStream(void)
 {
   return -1;
-}
-
-PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES*)
-{
-  return PVR_ERROR_NOT_IMPLEMENTED;
 }
 
 PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL*, PVR_NAMED_VALUE*, unsigned int*)

--- a/src/tvheadend/HTSPDemuxer.h
+++ b/src/tvheadend/HTSPDemuxer.h
@@ -76,9 +76,8 @@ public:
 
   bool IsTimeShifting() const;
   bool IsRealTimeStream() const;
-  int64_t GetTimeshiftTime() const;
-  int64_t GetTimeshiftBufferStart() const;
-  int64_t GetTimeshiftBufferEnd() const;
+  PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *times) const;
+
   uint32_t GetSubscriptionId() const;
   uint32_t GetChannelId() const;
   time_t GetLastUse() const;
@@ -124,6 +123,7 @@ private:
   tvheadend::status::DescrambleInfo m_descrambleInfo;
   tvheadend::Subscription m_subscription;
   std::atomic<time_t> m_lastUse;
+  std::atomic<time_t> m_startTime;
 };
 
 } // namespace tvheadend

--- a/src/tvheadend/HTSPVFS.cpp
+++ b/src/tvheadend/HTSPVFS.cpp
@@ -119,14 +119,6 @@ long long HTSPVFS::Seek ( long long pos, int whence )
   return SendFileSeek(pos, whence);
 }
 
-long long HTSPVFS::Tell ( void )
-{
-  if (m_fileId == 0)
-    return -1;
-
-  return m_offset;
-}
-
 long long HTSPVFS::Size ( void )
 {
   int64_t ret = -1;

--- a/src/tvheadend/HTSPVFS.h
+++ b/src/tvheadend/HTSPVFS.h
@@ -47,7 +47,6 @@ public:
   void Close();
   ssize_t Read(unsigned char *buf, unsigned int len);
   long long Seek(long long pos, int whence);
-  long long Tell();
   long long Size();
 
 private:


### PR DESCRIPTION
Implement API function GetStreamTimes (for tv/radion steam, recordings can be added later - currentyl tvh does not give access to recording times).

Remove implementation of deprecated API functions GetBufferTime(Start|End), GetPlayingTime, POsition(Recorded|Live)Stream, MoveChannel. 

Add support for PVR_CHANNEL_GROUP_MEMBER::iSubChannelNumber"

Details: https://github.com/xbmc/xbmc/pull/13228