### PR TITLE
4.2.10: Implement GetStreamTimes for recordings

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.2.9"
+  version="4.2.10"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>
@@ -182,6 +182,6 @@
     <disclaimer lang="zh_CN">这是不稳定版的软件！作者不对录像失败、错误定时造成时间浪费或其它不良影响负责。</disclaimer>
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
-    <news>Implemented GetStreamTimes API function. Updated to PVR Addon API 5.8.0.</news>
+    <news>Implemented GetStreamTimes API function for recordings.</news>
   </extension>
 </addon>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,5 +1,8 @@
+4.2.10
+- PVR API v5.5.0: Implemented GetStreamTimes for recordings
+
 4.2.9
-- PVR API v5.5.0: Implemented GetStreamTimes
+- PVR API v5.5.0: Implemented GetStreamTimes for TV/radio streams
 - PVR API v5.8.0: Dropped GetPlayingTime, GetBufferTimeStart, GetBufferTimeEnd, PositionRecordedStream, PositionLiveStream, MoveChannel
 - PVR API v5.8.0: Added support for PVR_CHANNEL_GROUP_MEMBER::iSubChannelNumber
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1670,10 +1670,9 @@ void CTvheadend::CloseExpiredSubscriptions()
     for (auto *dmx : m_dmx)
     {
       if (Settings::GetInstance().GetPreTunerCloseDelay() &&
-          dmx->GetLastUse() + Settings::GetInstance().GetPreTunerCloseDelay() < time(nullptr))
+          dmx->GetLastUse() + Settings::GetInstance().GetPreTunerCloseDelay() < std::time(nullptr))
       {
-        Logger::Log(LogLevel::LEVEL_TRACE, "untuning channel %u on subscription %u",
-                    m_channels[dmx->GetChannelId()].GetNum(), dmx->GetSubscriptionId());
+        Logger::Log(LogLevel::LEVEL_TRACE, "closing expired subscription %u", dmx->GetSubscriptionId());
         dmx->Close();
       }
     }

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -211,7 +211,6 @@ public:
   PVR_ERROR    DemuxCurrentDescramble( PVR_DESCRAMBLE_INFO *info);
   bool         DemuxIsTimeShifting() const;
   bool         DemuxIsRealTimeStream() const;
-  PVR_ERROR    DemuxGetStreamTimes(PVR_STREAM_TIMES *times) const;
 
   void CloseExpiredSubscriptions();
 
@@ -223,6 +222,11 @@ public:
   ssize_t VfsRead(unsigned char *buf, unsigned int len);
   long long VfsSeek(long long position, int whence);
   long long VfsSize();
+
+  /*
+   * stream times (live streams and recordings)
+   */
+  PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *times);
 
   /**
    * The streaming profiles available on the server
@@ -257,4 +261,6 @@ public:
   int m_epgMaxDays;
 
   bool m_playingLiveStream;
+  tvheadend::entity::Recording* m_playingRecording;
+
 };

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -267,8 +267,7 @@ PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *times)
   if (!times)
     return PVR_ERROR_INVALID_PARAMETERS;
 
-  // TODO: handle recordings
-  return tvh->DemuxGetStreamTimes(times);
+  return tvh->GetStreamTimes(times);
 }
 
 bool IsTimeshifting(void)

--- a/src/tvheadend/entity/Recording.h
+++ b/src/tvheadend/entity/Recording.h
@@ -63,6 +63,8 @@ namespace tvheadend
         m_stop(0),
         m_startExtra(0),
         m_stopExtra(0),
+        m_filesStart(0),
+        m_filesStop(0),
         m_state(PVR_TIMER_STATE_ERROR),
         m_lifetime(0),
         m_priority(50),   // Kodi default - "normal"
@@ -84,6 +86,8 @@ namespace tvheadend
                m_stop == other.m_stop &&
                m_startExtra == other.m_startExtra &&
                m_stopExtra == other.m_stopExtra &&
+               m_filesStart == other.m_filesStart &&
+               m_filesStop == other.m_filesStop &&
                m_title == other.m_title &&
                m_path == other.m_path &&
                m_description == other.m_description &&
@@ -164,6 +168,12 @@ namespace tvheadend
       int64_t GetStopExtra() const { return m_stopExtra; }
       void SetStopExtra(int64_t stopExtra) { m_stopExtra = stopExtra; }
 
+      int64_t GetFilesStart() const { return m_filesStart; }
+      void SetFilesStart(int64_t start) { m_filesStart = start; }
+
+      int64_t GetFilesStop() const { return m_filesStop; }
+      void SetFilesStop(int64_t stop) { m_filesStop = stop; }
+
       const std::string& GetTitle() const { return m_title; }
       void SetTitle(const std::string &title) { m_title = title; }
 
@@ -217,6 +227,8 @@ namespace tvheadend
       int64_t          m_stop;
       int64_t          m_startExtra;
       int64_t          m_stopExtra;
+      int64_t          m_filesStart;
+      int64_t          m_filesStop;
       std::string      m_title;
       std::string      m_subtitle;
       std::string      m_path;


### PR DESCRIPTION
This PR implements the API function `GetStreamTimes` for recordings. Previous PR only supported TV/radio streams.

Remark: For best results, a small tvheadend modification (https://github.com/tvheadend/tvheadend/pull/1076) is needed, but it works okayish (better as before), also with older tvheadend versions.

Finally, with the above mentioned tvh improvement, even playtimes for in-progress recordings do work (first time ever).

@Jalle19 ping.
  