### PR TITLE
Fixed crashes on addon destruction.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.2.10"
+  version="4.2.11"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>
@@ -182,6 +182,6 @@
     <disclaimer lang="zh_CN">这是不稳定版的软件！作者不对录像失败、错误定时造成时间浪费或其它不良影响负责。</disclaimer>
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
-    <news>Implemented GetStreamTimes API function for recordings.</news>
+    <news>Fixed crashes on addon destruction</news>
   </extension>
 </addon>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.2.11
+- Fixed crashes on addon destruction
+
 4.2.10
 - PVR API v5.5.0: Implemented GetStreamTimes for recordings
 

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -72,6 +72,7 @@ public:
   ~CTvheadend() override;
 
   void Start ( void );
+  void Stop ( void );
 
   // IHTSPConnectionListener implementation
   void Disconnected() override;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -126,6 +126,7 @@ ADDON_STATUS ADDON_GetStatus()
 void ADDON_Destroy()
 {
   CLockObject lock(g_mutex);
+  tvh->Stop();
   SAFE_DELETE(tvh);
   SAFE_DELETE(PVR);
   SAFE_DELETE(XBMC);
@@ -143,14 +144,12 @@ ADDON_STATUS ADDON_SetSetting
 
 void OnSystemSleep()
 {
-  if (tvh)
-    tvh->OnSleep();
+  tvh->OnSleep();
 }
 
 void OnSystemWake()
 {
-  if (tvh)
-    tvh->OnWake();
+  tvh->OnWake();
 }
 
 void OnPowerSavingActivated()


### PR DESCRIPTION
I noticed often crashes when deinstalling pvr.hts.

This PR fixes those crashes by:
- closing demuxers before closing tvh connection and stopping tvh worker thread
- ensuring CTvheadend thread worker function is exited when destructing the CTvheadend instance: `StopThread(0)` == "wait infinite" vs. `StopThread()`== "wait 5 secs" (5 secs are not enough sometimes). 

The rest of the code changes is small cosmetical stuff, like 
- introduce `CTvheadend::Stop` as counterpart to existing `CTvheadend::Start`
- do not check for `tvh`instance presence where not needed
- more intermediate `IsStopped`check points in `CTvheadend::Process`
  