### PR TITLE
Fix logspam caused by predicitve tuning

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.2.16"
+  version="4.2.17"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>
@@ -182,7 +182,6 @@
     <disclaimer lang="zh_CN">这是不稳定版的软件！作者不对录像失败、错误定时造成时间浪费或其它不良影响负责。</disclaimer>
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
-    <news>Recordings: Use real start time and duration if available. Recordings: Add support for season and episode number (tvh4.3+). New addon logo.
-</news>
+    <news>Fix predictive tuning (do not close subscriptions that never were active).</news>
   </extension>
 </addon>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,12 @@
+4.2.17
+- Fix predictive tuning (do not close subscriptions that never were active).
+
+4.2.16
+- updated language files from Transifex
+
+4.2.15
+- updated language files from Transifex
+
 4.2.14
 - PVR API 5.9.0 changes implemented
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1696,6 +1696,7 @@ void CTvheadend::CloseExpiredSubscriptions()
     for (auto *dmx : m_dmx)
     {
       if (Settings::GetInstance().GetPreTunerCloseDelay() &&
+          dmx->GetLastUse() > 0 &&
           dmx->GetLastUse() + Settings::GetInstance().GetPreTunerCloseDelay() < std::time(nullptr))
       {
         Logger::Log(LogLevel::LEVEL_TRACE, "closing expired subscription %u", dmx->GetSubscriptionId());


### PR DESCRIPTION
Fixes kodi.log spammed with 

<pre>
15:30:28.720 T:139859892864768   DEBUG: AddOnLog: Tvheadend HTSP Client: pvr.hts - closing expired subscription 0
15:30:28.720 T:139859892864768   DEBUG: AddOnLog: Tvheadend HTSP Client: pvr.hts - demux flush
15:30:28.720 T:139859892864768   DEBUG: AddOnLog: Tvheadend HTSP Client: pvr.hts - demux close
</pre>

when pvr.hts trace is enabled.

Should also have a positive performance impact.