### PR TITLE
Add setting to ignore duplicate scheduled recordings (tvh4.3+) 

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.3.3"
+  version="4.3.4"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>
@@ -182,6 +182,6 @@
     <disclaimer lang="zh_CN">这是不稳定版的软件！作者不对录像失败、错误定时造成时间浪费或其它不良影响负责。</disclaimer>
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
-    <news>PVR Addon API 5.10.0: Implemented recording stream read chunk size as addon setting.</news>
+    <news>Add setting to ignore duplicate scheduled recordings (tvh4.3+).</news>
   </extension>
 </addon>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.3.1
+- Add stub for "subscriptionGrace" HTSP method.
+
 4.3.0
 - PVR Addon API 5.10.0: Implemented recording stream read chunk size as addon setting.
 

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,5 +1,15 @@
-4.3.1
+4.3.4
 - Add stub for "subscriptionGrace" HTSP method.
+- Add setting to ignore duplicate scheduled recordings (tvh4.3+)
+
+4.3.3
+- updated language files from Transifex
+
+4.3.2
+- updated language files from Transifex
+
+4.3.1
+- updated language files from Transifex
 
 4.3.0
 - PVR Addon API 5.10.0: Implemented recording stream read chunk size as addon setting.

--- a/pvr.hts/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hts/resources/language/resource.language.en_gb/strings.po
@@ -100,7 +100,15 @@ msgctxt "#30058"
 msgid "Defaults for new timers"
 msgstr ""
 
-#empty strings from id 30059 to 30099
+msgctxt "#30059"
+msgid "Scheduled recordings"
+msgstr ""
+
+msgctxt "#30060"
+msgid "Ignore duplicates (tvh 4.3+)"
+msgstr ""
+
+#empty strings from id 30061 to 30099
 
 msgctxt "#30100"
 msgid "Data transfer"

--- a/pvr.hts/resources/settings.xml
+++ b/pvr.hts/resources/settings.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
   <category label="30000">
-	<setting id="host" type="text" label="30001" default="127.0.0.1" />
-	<setting id="http_port" type="number" option="int" label="30002" default="9981" />
-	<setting id="htsp_port" type="number" option="int" label="30003" default="9982" />
-	<setting id="user" type="text" label="30004" default="" />
-	<setting id="pass" type="text" label="30005" option="hidden" enable="!eq(-1,)" default="" />
-	<setting id="connect_timeout" type="slider" option="int" range="1,60" label="30006" default="10" />
-	<setting id="response_timeout" type="slider" option="int" range="1,60" label="30007" default="5" />
+    <setting id="host" type="text" label="30001" default="127.0.0.1" />
+    <setting id="http_port" type="number" option="int" label="30002" default="9981" />
+    <setting id="htsp_port" type="number" option="int" label="30003" default="9982" />
+    <setting id="user" type="text" label="30004" default="" />
+    <setting id="pass" type="text" label="30005" option="hidden" enable="!eq(-1,)" default="" />
+    <setting id="connect_timeout" type="slider" option="int" range="1,60" label="30006" default="10" />
+    <setting id="response_timeout" type="slider" option="int" range="1,60" label="30007" default="5" />
   </category>
-  
+
   <category label="30009">
     <setting label="30500" type="lsep"/>
     <setting id="streaming_profile" type="text" label="30501" default="" />
@@ -22,18 +22,21 @@
     <setting label="30503" type="lsep"/>
     <setting id="stream_readchunksize" type="slider" option="int" range="4,4,128" label="30504" default="64" />
   </category>
-  
+
   <category label="30010">
     <setting label="30050" type="lsep"/>
     <setting id="autorec_approxtime" type="enum" label="30051" lvalues="30052|30053" default="0"/>
     <setting id="autorec_maxdiff" enable="eq(-1,1)"  type="slider" option="int" range="0,5,120" label="30054" default="15" />
     
+    <setting label="30059" type="lsep"/>
+    <setting id="dvr_ignore_duplicates" type="bool" label="30060" default="true" />
+
     <setting label="30058" type="lsep"/>
     <setting id="dvr_priority" type="enum" label="30055" lvalues="30351|30352|30353|30354|30355" default="2"/>
     <setting id="dvr_lifetime" type="enum" label="30056" lvalues="30375|30376|30377|30378|30379|30380|30381|30382|30383|30384|30385|30386|30387|30388|30389" default="8"/>
     <setting id="dvr_dubdetect" type="enum" label="30057" lvalues="30356|30357|30358|30359|30360|30361" default="0"/>
   </category>
-  
+
   <category label="30008">
     <setting label="30100" type="lsep"/>
     <setting id="epg_async" type="bool" label="30101" default="false"/>

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -2243,6 +2243,13 @@ void CTvheadend::ParseRecordingAddOrUpdate ( htsmsg_t *msg, bool bAdd )
     return;
   }
 
+  /* Ignore duplicates */
+  uint32_t dup = 0;
+  if (Settings::GetInstance().GetIgnoreDuplicateSchedules() &&
+      !htsmsg_get_u32(msg, "duplicate", &dup) &&
+      dup == 1)
+    return;
+
   /* Get/create entry */
   Recording &rec = m_recordings[id];
   Recording comparison = rec;

--- a/src/tvheadend/HTSPDemuxer.cpp
+++ b/src/tvheadend/HTSPDemuxer.cpp
@@ -375,6 +375,8 @@ bool HTSPDemuxer::ProcessMessage ( const char *method, htsmsg_t *m )
     ParseSubscriptionSkip(m);
   else if (!strcmp("subscriptionSpeed", method))
     ParseSubscriptionSpeed(m);
+  else if (!strcmp("subscriptionGrace", method))
+    ParseSubscriptionGrace(m);
   else
     Logger::Log(LogLevel::LEVEL_DEBUG, "demux unhandled subscription message [%s]", method);
 
@@ -669,6 +671,10 @@ void HTSPDemuxer::ParseSubscriptionSpeed ( htsmsg_t *m )
     Flush();
     m_speedChange = false;
   }
+}
+
+void HTSPDemuxer::ParseSubscriptionGrace ( htsmsg_t *m )
+{
 }
 
 void HTSPDemuxer::ParseQueueStatus (htsmsg_t* m)

--- a/src/tvheadend/HTSPDemuxer.h
+++ b/src/tvheadend/HTSPDemuxer.h
@@ -103,6 +103,7 @@ private:
   void ParseSubscriptionStop(htsmsg_t *m);
   void ParseSubscriptionSkip(htsmsg_t *m);
   void ParseSubscriptionSpeed(htsmsg_t *m);
+  void ParseSubscriptionGrace(htsmsg_t *m);
   void ParseQueueStatus(htsmsg_t *m);
   void ParseSignalStatus(htsmsg_t *m);
   void ParseTimeshiftStatus(htsmsg_t *m);

--- a/src/tvheadend/Settings.cpp
+++ b/src/tvheadend/Settings.cpp
@@ -43,9 +43,10 @@ const int         Settings::DEFAULT_APPROX_TIME         = 0;  // don't use an ap
 const std::string Settings::DEFAULT_STREAMING_PROFILE   = "";
 const int         Settings::DEFAULT_DVR_PRIO            = DVR_PRIO_NORMAL;
 const int         Settings::DEFAULT_DVR_LIFETIME        = 8; // enum 8 = 3 months
-const int         Settings::DEFAULT_DVR_DUBDETECT       = DVR_AUTOREC_RECORD_ALL;
+const int         Settings::DEFAULT_DVR_DUPDETECT       = DVR_AUTOREC_RECORD_ALL;
 const bool        Settings::DEFAULT_DVR_PLAYSTATUS      = true;
 const int         Settings::DEFAULT_STREAM_CHUNKSIZE    = 64; // KB
+const bool        Settings::DEFAULT_DVR_IGNORE_DUPLICATE_SCHEDULES = true;
 
 void Settings::ReadSettings()
 {
@@ -81,13 +82,16 @@ void Settings::ReadSettings()
   /* Default dvr settings */
   SetDvrPriority(ReadIntSetting("dvr_priority", DEFAULT_DVR_PRIO));
   SetDvrLifetime(ReadIntSetting("dvr_lifetime", DEFAULT_DVR_LIFETIME));
-  SetDvrDupdetect(ReadIntSetting("dvr_dubdetect", DEFAULT_DVR_DUBDETECT));
+  SetDvrDupdetect(ReadIntSetting("dvr_dubdetect", DEFAULT_DVR_DUPDETECT));
 
   /* Sever based play status */
   SetDvrPlayStatus(ReadBoolSetting("dvr_playstatus", DEFAULT_DVR_PLAYSTATUS));
 
   /* Stream read chunk size */
   SetStreamReadChunkSizeKB(ReadIntSetting("stream_readchunksize", DEFAULT_STREAM_CHUNKSIZE));
+
+  /* Scheduled recordings */
+  SetIgnoreDuplicateSchedules(ReadBoolSetting("dvr_ignore_duplicates", DEFAULT_DVR_IGNORE_DUPLICATE_SCHEDULES));
 }
 
 ADDON_STATUS Settings::SetSetting(const std::string &key, const void *value)
@@ -160,6 +164,8 @@ ADDON_STATUS Settings::SetSetting(const std::string &key, const void *value)
     return SetBoolSetting(GetDvrPlayStatus(), value);
   else if (key == "stream_readchunksize")
     return SetIntSetting(GetStreamReadChunkSize(), value);
+  else if (key == "dvr_ignore_duplicates")
+    return SetBoolSetting(GetIgnoreDuplicateSchedules(), value);
   else
   {
     Logger::Log(LogLevel::LEVEL_ERROR, "Settings::SetSetting - unknown setting '%s'", key.c_str());

--- a/src/tvheadend/Settings.h
+++ b/src/tvheadend/Settings.h
@@ -52,9 +52,10 @@ namespace tvheadend {
     static const std::string DEFAULT_STREAMING_PROFILE;
     static const int         DEFAULT_DVR_PRIO;        // any dvr_prio_t numeric value
     static const int         DEFAULT_DVR_LIFETIME;    // 0..14 (0 = 1 day, 14 = forever)
-    static const int         DEFAULT_DVR_DUBDETECT;   // 0..5  (0 = record all, 5 = limit to once a day)
+    static const int         DEFAULT_DVR_DUPDETECT;   // 0..5  (0 = record all, 5 = limit to once a day)
     static const bool        DEFAULT_DVR_PLAYSTATUS;
     static const int         DEFAULT_STREAM_CHUNKSIZE; // KB
+    static const bool        DEFAULT_DVR_IGNORE_DUPLICATE_SCHEDULES;
 
     /**
      * Singleton getter for the instance
@@ -98,6 +99,7 @@ namespace tvheadend {
     int         GetDvrLifetime(bool asEnum = false) const;
     bool        GetDvrPlayStatus() const { return m_bDvrPlayStatus; }
     int         GetStreamReadChunkSize() const { return m_iStreamReadChunkSizeKB; }
+    bool        GetIgnoreDuplicateSchedules() const { return m_bIgnoreDuplicateSchedules; }
 
   private:
     Settings()
@@ -118,9 +120,10 @@ namespace tvheadend {
       m_strStreamingProfile(DEFAULT_STREAMING_PROFILE),
       m_iDvrPriority(DEFAULT_DVR_PRIO),
       m_iDvrLifetime(DEFAULT_DVR_LIFETIME),
-      m_iDvrDupdetect(DEFAULT_DVR_DUBDETECT),
+      m_iDvrDupdetect(DEFAULT_DVR_DUPDETECT),
       m_bDvrPlayStatus(DEFAULT_DVR_PLAYSTATUS),
-      m_iStreamReadChunkSizeKB(DEFAULT_STREAM_CHUNKSIZE) {}
+      m_iStreamReadChunkSizeKB(DEFAULT_STREAM_CHUNKSIZE),
+      m_bIgnoreDuplicateSchedules(DEFAULT_DVR_IGNORE_DUPLICATE_SCHEDULES) {}
 
     Settings(Settings const &) = delete;
     void operator=(Settings const &) = delete;
@@ -147,6 +150,7 @@ namespace tvheadend {
     void SetDvrDupdetect(int value) { m_iDvrDupdetect = value; }
     void SetDvrPlayStatus(bool value) { m_bDvrPlayStatus = value; }
     void SetStreamReadChunkSizeKB(int value) { m_iStreamReadChunkSizeKB = value; }
+    void SetIgnoreDuplicateSchedules(bool value) { m_bIgnoreDuplicateSchedules = value; }
 
     /**
      * Read/Set values according to definition in settings.xml
@@ -180,6 +184,7 @@ namespace tvheadend {
     int         m_iDvrDupdetect;
     bool        m_bDvrPlayStatus;
     int         m_iStreamReadChunkSizeKB;
+    bool        m_bIgnoreDuplicateSchedules;
   };
 
 }


### PR DESCRIPTION
See https://github.com/tvheadend/tvheadend/commit/30f9f7f2a62cab74f7c508849b8ccc4126791811

If the setting is activated (and tvh version is recent enough) only events actually scheduled for recording will be listed in Kodi. Otherwise, also duplicates appear. Functionality is similar to "show/hide duplicates" button in tvh 4.3 web ui:

<img width="803" alt="screen shot 2018-07-27 at 09 03 09" src="https://user-images.githubusercontent.com/3226626/43306635-11312b0e-917c-11e8-89b5-ca00fe26c6e9.png">

@Jalle19 mind taking a look.
