### PR TITLE
Demuxer: Do not reset starttime when re-subscribing.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.3.6"
+  version="4.3.7"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>
@@ -182,6 +182,5 @@
     <disclaimer lang="zh_CN">这是不稳定版的软件！作者不对录像失败、错误定时造成时间浪费或其它不良影响负责。</disclaimer>
     <disclaimer lang="zh_TW">這是測試版軟體！其原創作者並無法對於以下情況負責，包含：錄影失敗，不正確的定時設定，多餘時數，或任何產生的其它不良影響...</disclaimer>
     <platform>@PLATFORM@</platform>
-    <news>demuxer fixes</news>
   </extension>
 </addon>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,9 @@
+4.3.7
+- Fixed an edge case where wrong times were displayed in Kodi video/audio OSD
+
+4.3.6
+- updated language files from Transifex
+
 4.3.5
 - demuxer: fix begin/end pts precision
 - predictive tuning: do not close paused subscriptions

--- a/src/tvheadend/HTSPDemuxer.cpp
+++ b/src/tvheadend/HTSPDemuxer.cpp
@@ -59,7 +59,7 @@ void HTSPDemuxer::Connected ( void )
     m_subscription.SendSubscribe(0, 0, true);
     m_subscription.SendSpeed(0, true);
 
-    ResetStatus();
+    ResetStatus(false);
   }
 }
 
@@ -336,7 +336,7 @@ void HTSPDemuxer::SetStreamingProfile(const std::string &profile)
   m_subscription.SetProfile(profile);
 }
 
-void HTSPDemuxer::ResetStatus()
+void HTSPDemuxer::ResetStatus(bool resetStartTime /* = true */)
 {
   CLockObject lock(m_mutex);
 
@@ -345,7 +345,8 @@ void HTSPDemuxer::ResetStatus()
   m_descrambleInfo.Clear();
   m_timeshiftStatus.Clear();
 
-  m_startTime = 0;
+  if (resetStartTime)
+    m_startTime = 0;
 }
 
 /* **************************************************************************

--- a/src/tvheadend/HTSPDemuxer.h
+++ b/src/tvheadend/HTSPDemuxer.h
@@ -93,9 +93,10 @@ private:
   void Abort0();
 
   /**
-   * Resets the signal and quality info
+   * Resets the signal, quality, timeshift info and optionally the starttime
+   * @param resetStartTime if true, startTime will be reset
    */
-  void ResetStatus();
+  void ResetStatus(bool resetStartTime = true);
 
   void ParseMuxPacket(htsmsg_t *m);
   void ParseSourceInfo(htsmsg_t *m);


### PR DESCRIPTION
Fixes an edge case with wrong OSD times after a re-subscription when predictive tuning is active.