### PR TITLE
Add support for images for recordings via dvrEntryAdd message.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.3.7"
+  version="4.3.8"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.3.8
+- Add support for thumbnail image for recordings if supplied by tvheadend (tvh4.3+).
+
 4.3.7
 - Fixed an edge case where wrong times were displayed in Kodi video/audio OSD
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -440,6 +440,10 @@ PVR_ERROR CTvheadend::GetRecordings ( ADDON_HANDLE handle )
       strncpy(rec.strChannelName, recording.GetChannelName().c_str(),
               sizeof(rec.strChannelName) - 1);
 
+      /* Thumbnail image */
+      strncpy(rec.strThumbnailPath, recording.GetImage().c_str(),
+              sizeof(rec.strThumbnailPath) - 1);
+
       /* ID */
       snprintf(buf, sizeof(buf), "%i", recording.GetId());
       strncpy(rec.strRecordingId, buf, sizeof(rec.strRecordingId) - 1);
@@ -2466,6 +2470,8 @@ void CTvheadend::ParseRecordingAddOrUpdate ( htsmsg_t *msg, bool bAdd )
     rec.SetTimerecId(str);
   if ((str = htsmsg_get_str(msg, "autorecId")) != NULL)
     rec.SetAutorecId(str);
+  if ((str = htsmsg_get_str(msg, "image")) != NULL)
+    rec.SetImage(str);
 
   /* Error */
   if ((str = htsmsg_get_str(msg, "error")) != NULL)

--- a/src/tvheadend/entity/Recording.h
+++ b/src/tvheadend/entity/Recording.h
@@ -94,6 +94,7 @@ namespace tvheadend
                m_title == other.m_title &&
                m_path == other.m_path &&
                m_description == other.m_description &&
+               m_image == other.m_image &&
                m_timerecId == other.m_timerecId &&
                m_autorecId == other.m_autorecId &&
                m_state == other.m_state &&
@@ -192,6 +193,9 @@ namespace tvheadend
       const std::string& GetDescription() const { return m_description; }
       void SetDescription(const std::string &description) { m_description = description; }
 
+      const std::string& GetImage() const { return m_image; }
+      void SetImage(const std::string &image) { m_image = image; }
+
       const std::string& GetTimerecId() const { return m_timerecId; }
       void SetTimerecId(const std::string &autorecId) { m_timerecId = autorecId; }
 
@@ -248,6 +252,7 @@ namespace tvheadend
       std::string      m_subtitle;
       std::string      m_path;
       std::string      m_description;
+      std::string      m_image;
       std::string      m_timerecId;
       std::string      m_autorecId;
       PVR_TIMER_STATE  m_state;


### PR DESCRIPTION
This patch makes the recording image available when you browse recordings, similar to the existing EPG images.

Tvheadend supports one optional image URL per recording which is sent in the dvrEntryAdd message. Tvheadend gets this image URL via some xmltv programs.

We copy this in to all of the Kodi image paths (icon, thumbnail, fanart) since Kodi seems to scale/zoom the images. With the artwork I've tried, this seems reasonable and looks better than a blank background. But perhaps some xmltv sources only has very low-res images so we should exclude fanart?

For reference: the existing EPG code only has icon images and previously in recordings just the channel icon would appear next to the recordings with no fanart.

When you hit playback, and then press "info", the default skin displays a video camera icon instead of the recording artwork. I have the same behaviour with pvr.mythtv on Kodi master and Kodi 17.6. So I don't believe this patch is missing an extra line where the image path should be set.

I'm happy for the patch to just be modified to whatever is decided (e.g., not setting fanart), or I can re-submit.
