### PR TITLE
PVR Addon API 5.10.2: Implemented support for PVR_ADDON_CAPABILITIES.…

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.3.8"
+  version="4.3.9"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.3.9
+- PVR Addon API 5.10.2: Implemented support for PVR_ADDON_CAPABILITIES.bSupportsAsyncEPGTransfer
+
 4.3.8
 - Add support for thumbnail image for recordings if supplied by tvheadend (tvh4.3+).
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -179,6 +179,7 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
   pCapabilities->bSupportsRecordingPlayCount = (tvh->GetProtocol() >= 27 && Settings::GetInstance().GetDvrPlayStatus());
   pCapabilities->bSupportsLastPlayedPosition = (tvh->GetProtocol() >= 27 && Settings::GetInstance().GetDvrPlayStatus());
   pCapabilities->bSupportsDescrambleInfo     = true;
+  pCapabilities->bSupportsAsyncEPGTransfer   = Settings::GetInstance().GetAsyncEpg();
 
   if (tvh->GetProtocol() >= 28)
   {


### PR DESCRIPTION
…bSupportsAsyncEPGTransfer

For details see https://github.com/xbmc/xbmc/pull/14458

(Kodi now calls GetEPGForChannel only if it needs sync epg data. This happens when loading single epg events for timers outside configured epg window or after manual epg refresh for a channel was requested by the user.)