### PR TITLE
Add support for fanart images for recordings via dvrEntryAdd message.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.3.9"
+  version="4.3.10"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.3.10
+- Add support for fanart image for recordings if supplied by tvheadend (tvh4.3+).
+
 4.3.9
 - PVR Addon API 5.10.2: Implemented support for PVR_ADDON_CAPABILITIES.bSupportsAsyncEPGTransfer
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -444,6 +444,10 @@ PVR_ERROR CTvheadend::GetRecordings ( ADDON_HANDLE handle )
       strncpy(rec.strThumbnailPath, recording.GetImage().c_str(),
               sizeof(rec.strThumbnailPath) - 1);
 
+      /* Fanart image */
+      strncpy(rec.strFanartPath, recording.GetFanartImage().c_str(),
+              sizeof(rec.strFanartPath) - 1);
+
       /* ID */
       snprintf(buf, sizeof(buf), "%i", recording.GetId());
       strncpy(rec.strRecordingId, buf, sizeof(rec.strRecordingId) - 1);
@@ -2464,6 +2468,8 @@ void CTvheadend::ParseRecordingAddOrUpdate ( htsmsg_t *msg, bool bAdd )
     rec.SetAutorecId(str);
   if ((str = htsmsg_get_str(msg, "image")) != NULL)
     rec.SetImage(str);
+  if ((str = htsmsg_get_str(msg, "fanartImage")) != NULL)
+    rec.SetFanartImage(str);
 
   /* Error */
   if ((str = htsmsg_get_str(msg, "error")) != NULL)

--- a/src/tvheadend/entity/Recording.h
+++ b/src/tvheadend/entity/Recording.h
@@ -95,6 +95,7 @@ namespace tvheadend
                m_path == other.m_path &&
                m_description == other.m_description &&
                m_image == other.m_image &&
+               m_fanartImage == other.m_fanartImage &&
                m_timerecId == other.m_timerecId &&
                m_autorecId == other.m_autorecId &&
                m_state == other.m_state &&
@@ -196,6 +197,9 @@ namespace tvheadend
       const std::string& GetImage() const { return m_image; }
       void SetImage(const std::string &image) { m_image = image; }
 
+      const std::string& GetFanartImage() const { return m_fanartImage; }
+      void SetFanartImage(const std::string &image) { m_fanartImage = image; }
+
       const std::string& GetTimerecId() const { return m_timerecId; }
       void SetTimerecId(const std::string &autorecId) { m_timerecId = autorecId; }
 
@@ -253,6 +257,7 @@ namespace tvheadend
       std::string      m_path;
       std::string      m_description;
       std::string      m_image;
+      std::string      m_fanartImage;
       std::string      m_timerecId;
       std::string      m_autorecId;
       PVR_TIMER_STATE  m_state;


### PR DESCRIPTION
Tvheadend (4.3+) supports one optional fanart image URL per recording
which is sent in the dvrEntryAdd message. We copy this in to the Kodi fanart path.

Currently setting the fanart in Tvheadend for a recording is a manual process
via a manually run support script, but it will become automatic in the lifetime
of Kodi 18.
