### PR TITLE
Fix RDS stream support.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.4.1"
+  version="4.4.2"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.4.2
+- Fix RDS stream support. Only mpeg2 audio streams can contain embedded RDS data and there can be at most one RDS stream at a time.
+
 4.4.1
 - Fix creation of RDS streams. Must only be done if audio stream actually contains RDS data.
 

--- a/src/tvheadend/HTSPDemuxer.h
+++ b/src/tvheadend/HTSPDemuxer.h
@@ -130,6 +130,7 @@ private:
   tvheadend::Subscription m_subscription;
   std::atomic<time_t> m_lastUse;
   std::atomic<time_t> m_startTime;
+  uint32_t m_rdsIdx;
 };
 
 } // namespace tvheadend


### PR DESCRIPTION
Fixes https://github.com/xbmc/xbmc/issues/14722

Fix RDS stream support. Only mpeg2 audio streams can contain embedded RDS data and there can be at most one RDS stream at a time.

