### PR TITLE
4.4.5 - Fix buffer overflow in Logger::Log

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.4.4"
+  version="4.4.5"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,12 @@
+4.4.5
+- Fixed buffer overflow in Logger::Log
+
+4.4.4
+- updated language files from Transifex
+
+4.4.3
+- updated language files from Transifex
+
 4.4.2
 - Fix RDS stream support. Only mpeg2 audio streams can contain embedded RDS data and there can be at most one RDS stream at a time.
 

--- a/src/tvheadend/utilities/Logger.cpp
+++ b/src/tvheadend/utilities/Logger.cpp
@@ -21,7 +21,7 @@
 
 #include "Logger.h"
 
-#include <cstdarg>
+#include "p8-platform/util/StringUtils.h"
 
 using namespace tvheadend::utilities;
 
@@ -44,20 +44,21 @@ void Logger::Log(LogLevel level, const char *message, ...)
 {
   auto &logger = GetInstance();
 
-  char buffer[MESSAGE_BUFFER_SIZE];
-  std::string logMessage = message;
-  std::string prefix = logger.m_prefix;
+  std::string logMessage;
 
   // Prepend the prefix when set
+  const std::string prefix = logger.m_prefix;
   if (!prefix.empty())
-    logMessage = prefix + " - " + message;
+    logMessage = prefix + " - ";
+
+  logMessage += message;
 
   va_list arguments;
   va_start(arguments, message);
-  vsprintf(buffer, logMessage.c_str(), arguments);
+  logMessage = StringUtils::FormatV(logMessage.c_str(), arguments);
   va_end(arguments);
 
-  logger.m_implementation(level, buffer);
+  logger.m_implementation(level, logMessage.c_str());
 }
 
 void Logger::SetImplementation(LoggerImplementation implementation)

--- a/src/tvheadend/utilities/Logger.h
+++ b/src/tvheadend/utilities/Logger.h
@@ -80,8 +80,6 @@ namespace tvheadend
       void SetPrefix(const std::string &prefix);
 
     private:
-      static const unsigned int MESSAGE_BUFFER_SIZE = 16384;
-
       Logger();
 
       /**


### PR DESCRIPTION
Fixes a buffer overflow in Logger::Log as reported here: https://github.com/kodi-pvr/pvr.hts/issues/355#issuecomment-447844043

@Jalle19 good to go?
@dm38 fyi