### PR TITLE
remove space so markdown link works in github preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tvheadend PVR addon for Kodi
 
-This is a [Kodi] (http://kodi.tv) PVR addon for connecting to a [tvheadend](https://tvheadend.org) backend.
+This is a [Kodi](http://kodi.tv) PVR addon for connecting to a [tvheadend](https://tvheadend.org) backend.
 
 [![Build Status](https://travis-ci.org/kodi-pvr/pvr.hts.svg?branch=master)](https://travis-ci.org/kodi-pvr/pvr.hts)
 [![Build status](https://ci.appveyor.com/api/projects/status/9mh6hi08j00pto6x?svg=true)](https://ci.appveyor.com/project/MartijnKaijser/pvr-hts)


### PR DESCRIPTION
This is just a really minor "fix", but I wanted to also use this as way to say thank you to you guys! I am relatively new to Kodi, previously had tvheadend running in VLC, and it was mind-blowing how good this addon is integrated into Kodi. It feels so polished with all the things like recording, dvr guides, timeshifting, etc and it works really well too, which is a rare combination :)

Kudos to you