### PR TITLE
Increase the maximum allowed stream read chunk size to 512 KB

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.4.10"
+  version="4.4.11"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,12 @@
+4.4.11
+- increase the maximum stream chunk size to 512 KB
+
+4.4.10
+- updated language files from Transifex
+
+4.4.9
+- Fix a link in the README
+
 4.4.7
 - Add support for recent tvheadend 4.3 image URL changes (HTSP v34)
 

--- a/pvr.hts/resources/settings.xml
+++ b/pvr.hts/resources/settings.xml
@@ -20,7 +20,7 @@
     <setting id="pretuner_closedelay" enable="eq(-2,true)" type="slider" option="int" range="5,5,60" label="30402" default="10" />
 
     <setting label="30503" type="lsep"/>
-    <setting id="stream_readchunksize" type="slider" option="int" range="4,4,128" label="30504" default="64" />
+    <setting id="stream_readchunksize" type="slider" option="int" range="4,4,512" label="30504" default="64" />
   </category>
 
   <category label="30010">


### PR DESCRIPTION
256 KB seems to fix buffering issues for some people, so 512 KB should be a good maximum. Fixes #364 again.