### PR TITLE
4.4.12: Fix empty epg tag summary. Fixes #395

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.4.11"
+  version="4.4.12"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,8 +1,11 @@
+4.4.12
+- Fixed missing summary in EPG tags.
+
 4.4.11
-- increase the maximum stream chunk size to 512 KB
+- Increase the maximum stream chunk size to 512 KB
 
 4.4.10
-- updated language files from Transifex
+- Updated language files from Transifex
 
 4.4.9
 - Fix a link in the README

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -2457,7 +2457,6 @@ void CTvheadend::ParseRecordingAddOrUpdate ( htsmsg_t *msg, bool bAdd )
     rec.SetPath(str);
   if ((str = htsmsg_get_str(msg, "description")) != NULL)
     rec.SetDescription(str);
-  // TODO: What?
   else if ((str = htsmsg_get_str(msg, "summary")) != NULL)
     rec.SetDescription(str);
   if (!htsmsg_get_u32(msg, "contentType", &contentType))
@@ -2604,6 +2603,13 @@ bool CTvheadend::ParseEvent ( htsmsg_t *msg, bool bAdd, Event &evt )
     evt.SetSummary(str);
   if ((str = htsmsg_get_str(msg, "description")) != NULL)
     evt.SetDesc(str);
+  if (evt.GetDesc().empty() && m_conn->GetProtocol() >= 32)
+  {
+    // If no description is available, use summary as description. This was done by tvh prior to htsp version 32.
+    evt.SetDesc(evt.GetSummary());
+    // No duplicate description/summary
+    evt.SetSummary("");
+  }
   if ((str = htsmsg_get_str(msg, "image")) != NULL)
     evt.SetImage(GetImageURL(str));
   if (!htsmsg_get_u32(msg, "nextEventId", &u32))


### PR DESCRIPTION
Fixes #395 

Root cause: 4.4.7 needed a client htsp version bump, which triggers a functional change in behavior in newer tvh versions regarding epg tag summary handling in tvh which can lead to empty epg tag summaries.

@Jalle19 good to go?