### PR TITLE
Fix missing description in the EPG and DVR

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.4.12"
+  version="4.4.13"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.4.13
+- Fixed missing description in EPG and DVR tags.
+
 4.4.12
 - Fixed missing summary in EPG tags.
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -2470,6 +2470,20 @@ void CTvheadend::ParseRecordingAddOrUpdate ( htsmsg_t *msg, bool bAdd )
   if ((str = htsmsg_get_str(msg, "fanartImage")) != NULL)
     rec.SetFanartImage(GetImageURL(str));
 
+  if (m_conn->GetProtocol() >= 32) {
+    if (rec.GetDescription().empty() && !rec.GetSubtitle().empty()) {
+      /* 
+        Due to changes in HTSP v32, if the description is empty, try
+        to use the subtitle as the description. Clear the subtitle
+        afterwards to avoid duplicate information being displayed.
+
+        This was done by TVHeadend prior to HTSP v32.
+      */
+      rec.SetDescription(rec.GetSubtitle());
+      rec.SetSubtitle("");
+    }
+  }
+
   /* Error */
   if ((str = htsmsg_get_str(msg, "error")) != NULL)
   {


### PR DESCRIPTION
Some channels store the description in the channel subtitle in HTSP v32+. 
These commits fix the issue and update pvr.hts to 4.4.13.