### PR TITLE
4.4.14 Fix HTSPDemuxer::IsRealTimeStream to always return true if subscription is active.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.4.13"
+  version="4.4.14"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.4.14
+- Fix HTSPDemuxer::IsRealTimeStream to always return true if subscription is active.
+
 4.4.13
 - Fixed missing description in EPG and DVR tags.
 

--- a/src/tvheadend/HTSPDemuxer.cpp
+++ b/src/tvheadend/HTSPDemuxer.cpp
@@ -297,12 +297,7 @@ bool HTSPDemuxer::IsTimeShifting() const
 
 bool HTSPDemuxer::IsRealTimeStream() const
 {
-  if (!m_subscription.IsActive())
-    return false;
-
-  /* Handle as real time when reading close to the EOF (10 secs) */
-  CLockObject lock(m_mutex);
-  return (m_timeshiftStatus.shift < 10000000);
+  return m_subscription.IsActive();
 }
 
 PVR_ERROR HTSPDemuxer::GetStreamTimes(PVR_STREAM_TIMES *times) const


### PR DESCRIPTION
Details can be found here: https://github.com/kodi-pvr/pvr.hts/commit/f6d248a766fe1b6af318d7e66448e23f9bdb9565#r32349769