### PR TITLE
4.4.16: Fix auto close of timeshifted subscriptions if predictive tuning is activated.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.4.15"
+  version="4.4.16"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.4.16
+- Fix auto close of timeshifted subscriptions if predictive tuning is activated
+
 4.4.15
 - Fix/improve HTSPDemuxer timeshift support
 

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,5 +1,6 @@
 4.4.16
 - Fix auto close of timeshifted subscriptions if predictive tuning is activated
+- Increase packet queuedepth size for subscriptions to workaround timeshift stuttering problems
 
 4.4.15
 - Fix/improve HTSPDemuxer timeshift support

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1698,8 +1698,8 @@ void CTvheadend::CloseExpiredSubscriptions()
     {
       for (auto *dmx : m_dmx)
       {
-        // ignore paused subscriptions
-        if (dmx->IsTimeShifting())
+        // do not close the running subscription if it is currently paused
+        if (m_playingLiveStream && dmx == m_dmx_active && dmx->IsPaused())
           continue;
 
         time_t lastUse = dmx->GetLastUse();
@@ -2865,10 +2865,6 @@ bool CTvheadend::DemuxOpen( const PVR_CHANNEL &chn )
       m_dmx_active->Weight(SUBSCRIPTION_WEIGHT_POSTTUNING);
       prevId = m_dmx_active->GetChannelId();
 
-      /* Don't keep a timeshifting demux active */
-      if (m_dmx_active->IsTimeShifting())
-        m_dmx_active->Close();
-
       /* Promote the lingering subscription to the active one */
       dmx->Weight(SUBSCRIPTION_WEIGHT_NORMAL);
       m_dmx_active = dmx;
@@ -2889,10 +2885,6 @@ bool CTvheadend::DemuxOpen( const PVR_CHANNEL &chn )
 
   prevId = m_dmx_active->GetChannelId();
   m_dmx_active->Weight(SUBSCRIPTION_WEIGHT_POSTTUNING);
-
-  /* Don't keep a timeshifting demux active */
-  if (m_dmx_active->IsTimeShifting())
-    m_dmx_active->Close();
 
   m_playingLiveStream = oldest->Open(chn.iUniqueId, SUBSCRIPTION_WEIGHT_NORMAL);
   m_dmx_active = oldest;

--- a/src/tvheadend/HTSPDemuxer.cpp
+++ b/src/tvheadend/HTSPDemuxer.cpp
@@ -333,6 +333,13 @@ time_t HTSPDemuxer::GetLastUse() const
   return 0;
 }
 
+bool HTSPDemuxer::IsPaused() const
+{
+  if (m_subscription.IsActive())
+    return m_subscription.GetSpeed() == 0;
+  return false;
+}
+
 void HTSPDemuxer::SetStreamingProfile(const std::string &profile)
 {
   m_subscription.SetProfile(profile);

--- a/src/tvheadend/HTSPDemuxer.h
+++ b/src/tvheadend/HTSPDemuxer.h
@@ -81,6 +81,7 @@ public:
   uint32_t GetSubscriptionId() const;
   uint32_t GetChannelId() const;
   time_t GetLastUse() const;
+  bool IsPaused() const;
 
   /**
    * Tells each demuxer to use the specified profile for new subscriptions

--- a/src/tvheadend/Subscription.h
+++ b/src/tvheadend/Subscription.h
@@ -60,7 +60,7 @@ namespace tvheadend
     SUBSCRIPTION_PREPOSTTUNING                  = 10, /* used for pre and posttuning subscriptions (we do not care what the actual state is) */
   };
 
-  static const int PACKET_QUEUE_DEPTH = 2000000;
+  static const int PACKET_QUEUE_DEPTH = 10000000;
 
   class Subscription
   {


### PR DESCRIPTION
Fixes #406