### PR TITLE
Fix playback when skipping an in progress recording to real-time

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.4.16"
+  version="4.4.17"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.4.17
+- Fix playback when skipping an in progress recording to real-time.
+
 4.4.16
 - Fix auto close of timeshifted subscriptions if predictive tuning is activated
 - Increase packet queuedepth size for subscriptions to workaround timeshift stuttering problems

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1651,17 +1651,31 @@ void CTvheadend::VfsClose()
 
 ssize_t CTvheadend::VfsRead(unsigned char *buf, unsigned int len)
 {
-  return m_vfs->Read(buf, len);
+  return m_vfs->Read(buf, len, VfsIsActiveRecording());
 }
 
 long long CTvheadend::VfsSeek(long long position, int whence)
 {
-  return m_vfs->Seek(position, whence);
+  return m_vfs->Seek(position, whence, VfsIsActiveRecording());
 }
 
 long long CTvheadend::VfsSize()
 {
   return m_vfs->Size();
+}
+
+void CTvheadend::VfsPauseStream(bool paused)
+{
+  if (VfsIsActiveRecording())
+    m_vfs->PauseStream(paused);
+}
+
+bool CTvheadend::VfsIsRealTimeStream()
+{
+  if (VfsIsActiveRecording())
+    return m_vfs->IsRealTimeStream();
+  else
+    return false;
 }
 
 /* **************************************************************************

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -185,6 +185,11 @@ private:
   void ParseEventDelete          ( htsmsg_t *m );
   bool ParseEvent                ( htsmsg_t *msg, bool bAdd, tvheadend::entity::Event &evt );
 
+  /*
+   * VFS
+   */
+  bool VfsIsActiveRecording() const { return m_playingRecording && m_playingRecording->GetState() == PVR_TIMER_STATE_RECORDING; }
+
 public:
   /*
    * Connection (pass-thru)
@@ -223,6 +228,8 @@ public:
   ssize_t VfsRead(unsigned char *buf, unsigned int len);
   long long VfsSeek(long long position, int whence);
   long long VfsSize();
+  void VfsPauseStream(bool paused);
+  bool VfsIsRealTimeStream();
 
   /*
    * stream times (live streams and recordings)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -286,7 +286,10 @@ bool IsTimeshifting(void)
 
 bool IsRealTimeStream()
 {
-  return tvh->DemuxIsRealTimeStream();
+  if (tvh->m_playingRecording)
+    return tvh->VfsIsRealTimeStream();
+  else
+    return tvh->DemuxIsRealTimeStream();
 }
 
 bool OpenLiveStream(const PVR_CHANNEL &channel)
@@ -307,6 +310,12 @@ bool SeekTime(double time,bool backward,double *startpts)
 void SetSpeed(int speed)
 {
   tvh->DemuxSpeed(speed);
+}
+
+void PauseStream(bool paused)
+{
+  if (tvh->m_playingRecording)
+    tvh->VfsPauseStream(paused);
 }
 
 PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES* pProperties)
@@ -541,10 +550,6 @@ PVR_ERROR OpenDialogChannelSettings(const PVR_CHANNEL&)
 PVR_ERROR OpenDialogChannelAdd(const PVR_CHANNEL&)
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
-}
-
-void PauseStream(bool)
-{
 }
 
 int ReadLiveStream(unsigned char *, unsigned int)

--- a/src/tvheadend/HTSPVFS.cpp
+++ b/src/tvheadend/HTSPVFS.cpp
@@ -24,6 +24,9 @@ extern "C"
 {
 #include "libhts/htsmsg_binary.h"
 }
+#include <ctime>
+#include <chrono>
+#include <thread>
 
 #include "p8-platform/threads/mutex.h"
 #include "p8-platform/util/StringUtils.h"
@@ -40,7 +43,8 @@ using namespace tvheadend::utilities;
 * VFS handler
 */
 HTSPVFS::HTSPVFS ( HTSPConnection &conn )
-  : m_conn(conn), m_path(""), m_fileId(0), m_offset(0)
+  : m_conn(conn), m_path(""), m_fileId(0), m_offset(0),
+    m_eofOffsetSecs(-1), m_pauseTime(0), m_paused(false), m_isRealTimeStream(false)
 {
 }
 
@@ -73,6 +77,7 @@ bool HTSPVFS::Open ( const PVR_RECORDING &rec )
 
   /* Cache details */
   m_path = StringUtils::Format("dvr/%s", rec.strRecordingId);
+  m_fileStart = rec.recordingTime;
 
   /* Send open */
   if (!SendFileOpen())
@@ -93,30 +98,70 @@ void HTSPVFS::Close ( void )
   m_offset = 0;
   m_fileId = 0;
   m_path   = "";
+  m_eofOffsetSecs = -1;
+  m_pauseTime = 0;
+  m_paused = false;
+  m_isRealTimeStream = false;
 }
 
-ssize_t HTSPVFS::Read ( unsigned char *buf, unsigned int len )
+ssize_t HTSPVFS::Read ( unsigned char *buf, unsigned int len, bool inprogress )
 {
   /* Not opened */
   if (!m_fileId)
     return -1;
 
-  /* Read */
-  ssize_t read = SendFileRead(buf, len);
+  /* Tvheadend may briefly return 0 bytes when playing an in-progress recording at end-of-file
+     we'll retry 50 times with 10ms pauses (~500ms) before giving up */
+  int tries = inprogress ? 50 : 1;
+  ssize_t read = 0;
 
-  /* Update */
-  if (read > 0)
-    m_offset += read;
-
+  for (int i = 1; i <= tries; i++)
+  {
+    read = SendFileRead(buf, len);
+    if (read > 0)
+    {
+      m_offset += read;
+      return read;
+    }
+    else if (i < tries)
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  Logger::Log(LogLevel::LEVEL_DEBUG, "vfs read failed after %d attempts", tries);
   return read;
 }
 
-long long HTSPVFS::Seek ( long long pos, int whence )
+long long HTSPVFS::Seek ( long long pos, int whence, bool inprogress )
 {
   if (m_fileId == 0)
     return -1;
 
-  return SendFileSeek(pos, whence);
+  long long ret = SendFileSeek(pos, whence);
+
+  /* for inprogress recordings see whether we need to toggle IsRealTimeStream */
+  if (inprogress)
+  {
+    int64_t fileLengthSecs = std::time(nullptr) - m_fileStart;
+    int64_t fileSize = Size();
+    int64_t bitrate = 0;
+    m_eofOffsetSecs = -1;
+
+    if (fileLengthSecs > 0)
+      bitrate = fileSize / fileLengthSecs;
+
+    if (bitrate > 0)
+      m_eofOffsetSecs = (fileSize - m_offset) > 0 ? (fileSize - m_offset) / bitrate : 0;
+
+    /* only set m_isRealTimeStream within last 10 secs of an inprogress recording */
+    m_isRealTimeStream = (m_eofOffsetSecs >=0 && m_eofOffsetSecs < 10);
+    Logger::Log(LogLevel::LEVEL_TRACE, "vfs seek inprogress recording m_eofOffsetSecs=%lld m_isRealTimeStream=%d", static_cast<long long>(m_eofOffsetSecs), m_isRealTimeStream);
+
+    /* if we've seeked whilst paused then update m_pauseTime
+       this is so we correctly recalculate m_eofOffsetSecs when returning to normal playback */
+    if (m_paused)
+      m_pauseTime = std::time(nullptr);
+  }
+
+  return ret;
 }
 
 long long HTSPVFS::Size ( void )
@@ -148,6 +193,32 @@ long long HTSPVFS::Size ( void )
   htsmsg_destroy(m);
 
   return ret;
+}
+
+void HTSPVFS::PauseStream ( bool paused )
+{
+  m_paused = paused;
+
+  if (paused)
+  {
+    m_pauseTime = std::time(nullptr);
+  }
+  else
+  {
+    if (m_eofOffsetSecs >= 0 && m_pauseTime > 0)
+    {
+      /* correct m_eofOffsetSecs based on how long we've been paused */
+      m_eofOffsetSecs += (std::time(nullptr) - m_pauseTime);
+      m_isRealTimeStream = (m_eofOffsetSecs >=0 && m_eofOffsetSecs < 10);
+      Logger::Log(LogLevel::LEVEL_TRACE, "vfs unpause inprogress recording m_eofOffsetSecs=%lld m_isRealTimeStream=%d", static_cast<long long>(m_eofOffsetSecs), m_isRealTimeStream);
+    }
+    m_pauseTime = 0;
+  }
+}
+
+bool HTSPVFS::IsRealTimeStream ( void )
+{
+  return m_isRealTimeStream;
 }
 
 /* **************************************************************************

--- a/src/tvheadend/HTSPVFS.h
+++ b/src/tvheadend/HTSPVFS.h
@@ -45,9 +45,11 @@ public:
 
   bool Open(const PVR_RECORDING &rec);
   void Close();
-  ssize_t Read(unsigned char *buf, unsigned int len);
-  long long Seek(long long pos, int whence);
+  ssize_t Read(unsigned char *buf, unsigned int len, bool inprogress);
+  long long Seek(long long pos, int whence, bool inprogress);
   long long Size();
+  void PauseStream(bool paused);
+  bool IsRealTimeStream();
 
 private:
   bool SendFileOpen(bool force = false);
@@ -59,6 +61,11 @@ private:
   std::string m_path;
   uint32_t m_fileId;
   int64_t m_offset;
+  int64_t m_fileStart;
+  int64_t m_eofOffsetSecs;
+  int64_t m_pauseTime;
+  bool m_paused;
+  bool m_isRealTimeStream;
 };
 
 } // namespace tvheadend


### PR DESCRIPTION
## Description

This PR resolves issue #379: HTSPVFS and in progress recordings

## Motivation and Context

Currently, if you skip right to the end of an in progress recording, then the playback completely chokes; i.e. both the audio and video break up badly, the video freezes, and the audio makes popping noises.

On debugging, I found that the main issue was that Tvheadend can briefly return 0 bytes when playing an in-progress recording towards EOF; the demuxer expects at least 1 bytes to be returned.

My PR resolves this issue by adjusting HTSPVFS::Read() to retry when 0 bytes are returned for an in-progress recording.

After fixing this problem, the other issue I found was that Kodi would buffer for around 10 seconds when skipping fwd to real-time, before eventually resuming normal playback. After some debugging and research I landed on the IsRealTimeStream API call. This PR returns true for IsRealTimeStream when playback is within the last 10 seconds of an in-progress recording.

## How Has This Been Tested?

My testing was over a Gigabit Ethernet using both HD and SD channels.

Backend: TVheadend (v4.2.8) running on a 10yr old HTPC (Acer Revo 3700) running Debian Stretch
Kodi: Running on a Vero4K+ using OSMC Leia nightlies with pvr.hts v4.4.16 (+ this patch).

In this setup, I have conducted several tests as follows:

* Watched a normal, completed recording from start to finish to ensure no regressions were introduced for normal recordings. Also added extra debug logging to show the value of IsRealTimeStream, and could see it was always set to false as it always has been.
* Played an in-progress recording and skipped way beyond real-time playback. This caused the seek to 'snap back' to the end of file i.e. "Real-time" playback.  Playback started almost immediately (buffering circle appeared for only a split second), and playback was fine thereafter.
* Played an in-progress recording (1hr long) and skipped to real-time playback. Then watched the recording right to the end. No stutters or playback issues were observed, and when the show finished the playback ended immediately.
* With extra debugging in place, I monitored the value of IsRealTimeStream on an in-progress recording. I performed several small skip operations, and IsRealTimeStream was only set to true when nearing the end of the file (within last 10 seconds).
* Played LiveTV and also tried skipping backwards and forwards in the timeshift buffer to ensure no regressions were introduced in this area.
* Repeated the tests of skipping an in-progress recording to real-time playback using different chunk sizes. I have tried with both the minimum (4KB) and maximum (512KB) and playback was fine in all cases.
* Tried starting a recording and playing it almost immediately after. Playback was fine and I skipped forward (+2-3 seconds) to real-time playback without any problems / buffering /stuttering.

New tests added (16/04):
* Skip forward to real-time playback, then hit pause for 10 seconds, hit play and watch the logfile to ensure that IsRealTimeStream is set to false
* Skip forward to real-time playback, hit pause, then hit skip back (10 seconds) followed by play. Watch the logfile to ensure that IsRealTimeStream is set back to false.
* Pause an in progress recording (non real-time); whilst paused, skip forward to real-time then hit play. Ensure that IsRealTimeStream is set to true.
* Pause an in progress recording (non real-time); whilst paused, skip forward to real-time, then wait >10 seconds, then hit play. Ensure that IsRealTimeStream is set to false.
