### PR TITLE
4.4.18: Predictive tuning: Fix unability to retune to a channel that …

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.4.17"
+  version="4.4.18"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.4.18
+- Predictive tuning: Fix unability to retune to a channel that was closed immediately before.
+
 4.4.17
 - Fix playback when skipping an in progress recording to real-time.
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -2870,24 +2870,29 @@ bool CTvheadend::DemuxOpen( const PVR_CHANNEL &chn )
    * we reuse that subscription */
   for (auto *dmx : m_dmx)
   {
-    if (dmx != m_dmx_active && dmx->GetChannelId() == chn.iUniqueId)
+    if (dmx->GetChannelId() == chn.iUniqueId)
     {
       Logger::Log(LogLevel::LEVEL_TRACE, "retuning channel %u on subscription %u",
                m_channels[chn.iUniqueId].GetNum(), dmx->GetSubscriptionId());
 
-      /* Lower the priority on the current subscrption */
-      m_dmx_active->Weight(SUBSCRIPTION_WEIGHT_POSTTUNING);
-      prevId = m_dmx_active->GetChannelId();
+      if (dmx != m_dmx_active)
+      {
+        /* Lower the priority on the current subscrption */
+        m_dmx_active->Weight(SUBSCRIPTION_WEIGHT_POSTTUNING);
+        prevId = m_dmx_active->GetChannelId();
 
-      /* Promote the lingering subscription to the active one */
-      dmx->Weight(SUBSCRIPTION_WEIGHT_NORMAL);
-      m_dmx_active = dmx;
+        /* Promote the lingering subscription to the active one */
+        dmx->Weight(SUBSCRIPTION_WEIGHT_NORMAL);
+        m_dmx_active = dmx;
 
-      PredictiveTune(prevId, chn.iUniqueId);
-      m_streamchange = true;
+        PredictiveTune(prevId, chn.iUniqueId);
+        m_streamchange = true;
+      }
+
       m_playingLiveStream = true;
       return true;
     }
+
     if (dmx->GetLastUse() < oldest->GetLastUse())
       oldest = dmx;
   }
@@ -2950,7 +2955,9 @@ void CTvheadend::DemuxFlush ( void )
 
 void CTvheadend::DemuxAbort ( void )
 {
-  m_dmx_active->Abort();
+  // If predictive tuning is active, demuxers will be closed/aborted automatically once they are expired.
+  if (m_dmx.size() == 1)
+    m_dmx_active->Abort();
 }
 
 bool CTvheadend::DemuxSeek ( double time, bool backward, double *startpts )


### PR DESCRIPTION
…was closed immediately before.

Leia backport of #420