### PR TITLE
Recompile for 6.1.0 PVR Addon API compatibility

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="5.1.1"
+  version="5.2.0"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+5.2.0
+- Update: Recompile for 6.1.0 PVR Addon API compatibility
+
 5.1.1
 - Update build system version and cleanup
 - Change kodi header include way


### PR DESCRIPTION
5.2.0
- Update: Recompile for 6.1.0 PVR Addon API compatibility