### PR TITLE
Avoid using zero when season/episode information is not present

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="5.4.0"
+  version="5.4.1"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+5.4.1
+- Avoid using zero when season/episode information is not present
+
 5.4.0
 - Add HTTPS connection option
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -2567,11 +2567,11 @@ void CTvheadend::ParseRecordingAddOrUpdate(htsmsg_t* msg, bool bAdd)
   /* season/episode/part */
   uint32_t season = 0;
   if (!htsmsg_get_u32(msg, "seasonNumber", &season))
-    rec.SetSeason(season);
+    rec.SetSeason(static_cast<int32_t>(season));
 
   uint32_t episode = 0;
   if (!htsmsg_get_u32(msg, "episodeNumber", &episode))
-    rec.SetEpisode(episode);
+    rec.SetEpisode(static_cast<int32_t>(episode));
 
   uint32_t part = 0;
   if (!htsmsg_get_u32(msg, "partNumber", &part))
@@ -2694,9 +2694,9 @@ bool CTvheadend::ParseEvent(htsmsg_t* msg, bool bAdd, Event& evt)
   if (!htsmsg_get_s64(msg, "firstAired", &s64))
     evt.SetAired(static_cast<time_t>(s64));
   if (!htsmsg_get_u32(msg, "seasonNumber", &u32))
-    evt.SetSeason(u32);
+    evt.SetSeason(static_cast<int32_t>(u32));
   if (!htsmsg_get_u32(msg, "episodeNumber", &u32))
-    evt.SetEpisode(u32);
+    evt.SetEpisode(static_cast<int32_t>(u32));
   if (!htsmsg_get_u32(msg, "partNumber", &u32))
     evt.SetPart(u32);
 

--- a/src/tvheadend/entity/Event.h
+++ b/src/tvheadend/entity/Event.h
@@ -52,8 +52,8 @@ public:
       m_stars(0),
       m_age(0),
       m_aired(0),
-      m_season(0),
-      m_episode(0),
+      m_season(-1),
+      m_episode(-1),
       m_part(0),
       m_recordingId(0),
       m_year(0)
@@ -102,11 +102,11 @@ public:
   time_t GetAired() const { return m_aired; }
   void SetAired(time_t aired) { m_aired = aired; }
 
-  uint32_t GetSeason() const { return m_season; }
-  void SetSeason(uint32_t season) { m_season = season; }
+  int32_t GetSeason() const { return m_season; }
+  void SetSeason(int32_t season) { m_season = season; }
 
-  uint32_t GetEpisode() const { return m_episode; }
-  void SetEpisode(uint32_t episode) { m_episode = episode; }
+  int32_t GetEpisode() const { return m_episode; }
+  void SetEpisode(int32_t episode) { m_episode = episode; }
 
   uint32_t GetPart() const { return m_part; }
   void SetPart(uint32_t part) { m_part = part; }
@@ -157,8 +157,8 @@ private:
   uint32_t m_stars; /* 1 - 5 */
   uint32_t m_age; /* years */
   time_t m_aired;
-  uint32_t m_season;
-  uint32_t m_episode;
+  int32_t m_season;
+  int32_t m_episode;
   uint32_t m_part;
   std::string m_title;
   std::string m_subtitle; /* episode name */

--- a/src/tvheadend/entity/Recording.h
+++ b/src/tvheadend/entity/Recording.h
@@ -72,8 +72,8 @@ public:
       m_playCount(0),
       m_playPosition(0),
       m_contentType(0),
-      m_season(0),
-      m_episode(0),
+      m_season(-1),
+      m_episode(-1),
       m_part(0)
   {
   }
@@ -210,11 +210,11 @@ public:
   uint32_t GetGenreType() const { return m_contentType * 0x10; }
   uint32_t GetGenreSubType() const { return 0; }
 
-  uint32_t GetSeason() const { return m_season; }
-  void SetSeason(uint32_t season) { m_season = season; }
+  int32_t GetSeason() const { return m_season; }
+  void SetSeason(int32_t season) { m_season = season; }
 
-  uint32_t GetEpisode() const { return m_episode; }
-  void SetEpisode(uint32_t episode) { m_episode = episode; }
+  int32_t GetEpisode() const { return m_episode; }
+  void SetEpisode(int32_t episode) { m_episode = episode; }
 
   uint32_t GetPart() const { return m_part; }
   void SetPart(uint32_t part) { m_part = part; }
@@ -246,8 +246,8 @@ private:
   uint32_t m_playCount;
   uint32_t m_playPosition;
   uint32_t m_contentType;
-  uint32_t m_season;
-  uint32_t m_episode;
+  int32_t m_season;
+  int32_t m_episode;
   uint32_t m_part;
 };
 


### PR DESCRIPTION
The pvr.hts addon always sets the season number to 0, even when there is no season information available in Tvheadend. 

In Leia, this causes a display issue when the Tvheadend event or recording only has an Episode number but no Season number. As shown in these screenshots; kodi believes the Season Number is 0 and therefore treats this as a Special episode:

![screenshot1](https://user-images.githubusercontent.com/14977362/76315523-c1101e00-62d0-11ea-9bce-77175be684e4.png)

![screenshot2](https://user-images.githubusercontent.com/14977362/76315532-c66d6880-62d0-11ea-8a42-fbff1f79595d.png)

This is only a minor display issue. However, it will be made worse in Matrix owing to the following commit:

https://github.com/xbmc/xbmc/commit/3375a26606b3a6913bea18f4ef7b85a72b724915

This will mean that all events and recordings without any season/episode information in Tvheadend will always been shown as S0.

This can be easily resolved by initializing m_season and m_episode (for completeness) to -1.