### PR TITLE
4.4.21: Avoid using zero when season/episode information is not present

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="4.4.20"
+  version="4.4.21"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+4.4.21
+- Avoid using zero when season/episode information is not present
+
 4.4.20
 - Fixed: 'Stop recording' no longer aborts in-progress recordings (HTSP v26)
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -2543,9 +2543,9 @@ void CTvheadend::ParseRecordingAddOrUpdate ( htsmsg_t *msg, bool bAdd )
 
   /* season/episode/part */
   if (!htsmsg_get_u32(msg, "seasonNumber", &season))
-    rec.SetSeason(season);
+    rec.SetSeason(static_cast<int32_t>(season));
   if (!htsmsg_get_u32(msg, "episodeNumber", &episode))
-    rec.SetEpisode(episode);
+    rec.SetEpisode(static_cast<int32_t>(episode));
   if (!htsmsg_get_u32(msg, "partNumber", &part))
     rec.SetPart(part);
 
@@ -2654,9 +2654,9 @@ bool CTvheadend::ParseEvent ( htsmsg_t *msg, bool bAdd, Event &evt )
   if (!htsmsg_get_s64(msg, "firstAired", &s64))
     evt.SetAired((time_t)s64);
   if (!htsmsg_get_u32(msg, "seasonNumber", &u32))
-    evt.SetSeason(u32);
+    evt.SetSeason(static_cast<int32_t>(u32));
   if (!htsmsg_get_u32(msg, "episodeNumber", &u32))
-    evt.SetEpisode(u32);
+    evt.SetEpisode(static_cast<int32_t>(u32));
   if (!htsmsg_get_u32(msg, "partNumber", &u32))
     evt.SetPart(u32);
   if ((str = htsmsg_get_str(msg, "serieslinkUri")) != NULL)

--- a/src/tvheadend/entity/Event.h
+++ b/src/tvheadend/entity/Event.h
@@ -50,8 +50,8 @@ namespace tvheadend
         m_stars(0),
         m_age(0),
         m_aired(0),
-        m_season(0),
-        m_episode(0),
+        m_season(-1),
+        m_episode(-1),
         m_part(0),
         m_recordingId(0),
         m_year(0)
@@ -117,11 +117,11 @@ namespace tvheadend
       time_t GetAired() const { return m_aired; }
       void SetAired(time_t aired) { m_aired = aired; }
 
-      uint32_t GetSeason() const { return m_season; }
-      void SetSeason(uint32_t season) { m_season = season; }
+      int32_t GetSeason() const { return m_season; }
+      void SetSeason(int32_t season) { m_season = season; }
 
-      uint32_t GetEpisode() const { return m_episode; }
-      void SetEpisode(uint32_t episode) { m_episode = episode; }
+      int32_t GetEpisode() const { return m_episode; }
+      void SetEpisode(int32_t episode) { m_episode = episode; }
 
       uint32_t GetPart() const { return m_part; }
       void SetPart(uint32_t part) { m_part = part; }
@@ -172,8 +172,8 @@ namespace tvheadend
       uint32_t    m_stars; /* 1 - 5 */
       uint32_t    m_age;   /* years */
       time_t      m_aired;
-      uint32_t    m_season;
-      uint32_t    m_episode;
+      int32_t     m_season;
+      int32_t     m_episode;
       uint32_t    m_part;
       std::string m_title;
       std::string m_subtitle; /* episode name */

--- a/src/tvheadend/entity/Recording.h
+++ b/src/tvheadend/entity/Recording.h
@@ -71,8 +71,8 @@ namespace tvheadend
         m_playCount(0),
         m_playPosition(0),
         m_contentType(0),
-        m_season(0),
-        m_episode(0),
+        m_season(-1),
+        m_episode(-1),
         m_part(0)
       {
       }
@@ -231,11 +231,11 @@ namespace tvheadend
       uint32_t GetGenreType() const { return m_contentType * 0x10; }
       uint32_t GetGenreSubType() const { return 0; }
 
-      uint32_t GetSeason() const { return m_season; }
-      void SetSeason(uint32_t season) { m_season = season; }
+      int32_t GetSeason() const { return m_season; }
+      void SetSeason(int32_t season) { m_season = season; }
 
-      uint32_t GetEpisode() const { return m_episode; }
-      void SetEpisode(uint32_t episode) { m_episode = episode; }
+      int32_t GetEpisode() const { return m_episode; }
+      void SetEpisode(int32_t episode) { m_episode = episode; }
 
       uint32_t GetPart() const { return m_part; }
       void SetPart(uint32_t part) { m_part = part; }
@@ -267,8 +267,8 @@ namespace tvheadend
       uint32_t         m_playCount;
       uint32_t         m_playPosition;
       uint32_t         m_contentType;
-      uint32_t         m_season;
-      uint32_t         m_episode;
+      int32_t          m_season;
+      int32_t          m_episode;
       uint32_t         m_part;
     };
   }


### PR DESCRIPTION
Backport of #443 