### PR TITLE
Fix pointer to freed memory in EPG_TAG.strFirstAired.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="5.4.2"
+  version="5.4.3"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+5.4.3
+- Fixed pointer to freed memory in EPG_TAG.strFirstAired
+
 5.4.2
 - Update PVR API 6.2.0
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1385,20 +1385,6 @@ PVR_ERROR CTvheadend::UpdateTimer(const PVR_TIMER& timer)
  * EPG
  * *************************************************************************/
 
-namespace
-{
-
-std::string ParseAsW3CDateString(time_t time)
-{
-  std::tm* tm = std::localtime(&time);
-  char buffer[16];
-  std::strftime(buffer, 16, "%Y-%m-%d", tm);
-
-  return buffer;
-}
-
-} // unnamed namespace
-
 void CTvheadend::CreateEvent(const Event& event, EPG_TAG& epg)
 {
   epg = {0};
@@ -1427,8 +1413,7 @@ void CTvheadend::CreateEvent(const Event& event, EPG_TAG& epg)
       epg.strGenreDescription = categories.c_str();
     }
   }
-  std::string strFirstAired((event.GetAired() > 0) ? ParseAsW3CDateString(event.GetAired()) : "");
-  epg.strFirstAired = strFirstAired.c_str();
+  epg.strFirstAired = event.GetAired().c_str();
   epg.iParentalRating = event.GetAge();
   epg.iStarRating = event.GetStars();
   epg.iSeriesNumber = event.GetSeason();

--- a/src/tvheadend/entity/Event.cpp
+++ b/src/tvheadend/entity/Event.cpp
@@ -24,6 +24,8 @@
 #include "kodi/xbmc_epg_types.h"
 #include "p8-platform/util/StringUtils.h"
 
+#include <ctime>
+
 using namespace tvheadend::entity;
 
 void Event::SetWriters(const std::vector<std::string>& writers)
@@ -44,4 +46,20 @@ void Event::SetCast(const std::vector<std::string>& cast)
 void Event::SetCategories(const std::vector<std::string>& categories)
 {
   m_categories = StringUtils::Join(categories, EPG_STRING_TOKEN_SEPARATOR);
+}
+
+void Event::SetAired(time_t aired)
+{
+  if (aired > 0)
+  {
+    // convert to W3C date string
+    std::tm* tm = std::localtime(&aired);
+    char buffer[16];
+    std::strftime(buffer, 16, "%Y-%m-%d", tm);
+    m_aired = buffer;
+  }
+  else
+  {
+    m_aired.clear();
+  }
 }

--- a/src/tvheadend/entity/Event.h
+++ b/src/tvheadend/entity/Event.h
@@ -51,7 +51,6 @@ public:
       m_stop(0),
       m_stars(0),
       m_age(0),
-      m_aired(0),
       m_season(-1),
       m_episode(-1),
       m_part(-1),
@@ -99,9 +98,6 @@ public:
   uint32_t GetAge() const { return m_age; }
   void SetAge(uint32_t age) { m_age = age; }
 
-  time_t GetAired() const { return m_aired; }
-  void SetAired(time_t aired) { m_aired = aired; }
-
   int32_t GetSeason() const { return m_season; }
   void SetSeason(int32_t season) { m_season = season; }
 
@@ -148,6 +144,9 @@ public:
   const std::string& GetCategories() const { return m_categories; }
   void SetCategories(const std::vector<std::string>& categories);
 
+  const std::string& GetAired() const { return m_aired; }
+  void SetAired(time_t aired);
+
 private:
   uint32_t m_next;
   uint32_t m_channel;
@@ -156,7 +155,6 @@ private:
   time_t m_stop;
   uint32_t m_stars; /* 1 - 5 */
   uint32_t m_age; /* years */
-  time_t m_aired;
   int32_t m_season;
   int32_t m_episode;
   uint32_t m_part;
@@ -172,6 +170,7 @@ private:
   std::string m_directors;
   std::string m_cast;
   std::string m_categories;
+  std::string m_aired;
 };
 
 } // namespace entity


### PR DESCRIPTION
Fixes a regression introduced by #445 