### PR TITLE
5.5.0 Add support for recording file size

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="5.4.8"
+  version="5.5.0"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+5.5.0
+- Add support for recording file size (HTSP v35)
+
 5.4.8
 - Update PVR API 6.5.0
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -469,6 +469,9 @@ PVR_ERROR CTvheadend::GetRecordings(ADDON_HANDLE handle)
       rec.recordingTime = static_cast<time_t>(start);
       rec.iDuration = static_cast<int>(stop - start);
 
+      /* File size */
+      rec.sizeInBytes = recording.GetFilesSize();
+
       /* Priority */
       rec.iPriority = recording.GetPriority();
 
@@ -2297,6 +2300,7 @@ void CTvheadend::ParseRecordingAddOrUpdate(htsmsg_t* msg, bool bAdd)
 
     start = 0;
     stop = 0;
+    int64_t size = 0;
 
     htsmsg_field_t* file = nullptr;
     HTSMSG_FOREACH(file, files) // Loop through all files
@@ -2333,11 +2337,15 @@ void CTvheadend::ParseRecordingAddOrUpdate(htsmsg_t* msg, bool bAdd)
 
       if (!htsmsg_get_s64(&file->hmf_msg, "stop", &s64) && stop < s64)
         stop = s64;
+
+      if (!htsmsg_get_s64(&file->hmf_msg, "size", &s64))
+        size += s64;
     }
 
     // Set the times the recording actually started/stopped. They may differ from the scheduled start/stop.
     rec.SetFilesStart(start);
     rec.SetFilesStop(stop);
+    rec.SetFilesSize(size);
 
     /* Channel type fallback (in case channel was deleted) */
     if (needChannelType)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -185,6 +185,9 @@ PVR_ERROR GetCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
       ++i;
     }
   }
+
+  pCapabilities->bSupportsRecordingSize = tvh->GetProtocol() >= 35;
+
   return PVR_ERROR_NO_ERROR;
 }
 

--- a/src/tvheadend/entity/Recording.h
+++ b/src/tvheadend/entity/Recording.h
@@ -53,6 +53,7 @@ public:
       m_stopExtra(0),
       m_filesStart(0),
       m_filesStop(0),
+      m_filesSize(0),
       m_state(PVR_TIMER_STATE_ERROR),
       m_lifetime(0),
       m_priority(50), // Kodi default - "normal"
@@ -72,7 +73,7 @@ public:
            m_eventId == other.m_eventId && m_start == other.m_start && m_stop == other.m_stop &&
            m_startExtra == other.m_startExtra && m_stopExtra == other.m_stopExtra &&
            m_filesStart == other.m_filesStart && m_filesStop == other.m_filesStop &&
-           m_title == other.m_title && m_path == other.m_path &&
+           m_filesSize == other.m_filesSize && m_title == other.m_title && m_path == other.m_path &&
            m_description == other.m_description && m_image == other.m_image &&
            m_fanartImage == other.m_fanartImage && m_timerecId == other.m_timerecId &&
            m_autorecId == other.m_autorecId && m_state == other.m_state &&
@@ -148,6 +149,9 @@ public:
   int64_t GetFilesStop() const { return m_filesStop; }
   void SetFilesStop(int64_t stop) { m_filesStop = stop; }
 
+  int64_t GetFilesSize() const { return m_filesSize; }
+  void SetFilesSize(int64_t size) { m_filesSize = size; }
+
   const std::string& GetTitle() const { return m_title; }
   void SetTitle(const std::string& title) { m_title = title; }
 
@@ -218,6 +222,7 @@ private:
   int64_t m_stopExtra;
   int64_t m_filesStart;
   int64_t m_filesStop;
+  int64_t m_filesSize;
   std::string m_title;
   std::string m_subtitle;
   std::string m_path;


### PR DESCRIPTION
Implements support for Kodi 19 feature: https://github.com/xbmc/xbmc/pull/17538

**Depends on https://github.com/tvheadend/tvheadend/pull/1332. Please do not merge until the tvheadend PR got merged.**