### PR TITLE
[Settings] Change default DVR lifetime to forever

### DIFF
--- a/pvr.hts/resources/settings.xml
+++ b/pvr.hts/resources/settings.xml
@@ -202,7 +202,7 @@
         </setting>
         <setting id="dvr_lifetime" type="integer" label="30056" help="-1">
           <level>0</level>
-          <default>8</default> <!-- 3 months -->
+          <default>14</default> <!-- forever -->
           <constraints>
             <options>
               <option label="30375">0</option> <!-- 1 day -->

--- a/src/tvheadend/Settings.cpp
+++ b/src/tvheadend/Settings.cpp
@@ -35,7 +35,7 @@ const int Settings::DEFAULT_APPROX_TIME =
     0; // don't use an approximate start time, use a fixed time instead for auto recordings
 const std::string Settings::DEFAULT_STREAMING_PROFILE = "";
 const int Settings::DEFAULT_DVR_PRIO = DVR_PRIO_NORMAL;
-const int Settings::DEFAULT_DVR_LIFETIME = 8; // enum 8 = 3 months
+const int Settings::DEFAULT_DVR_LIFETIME = 14; // enum 14 = forever
 const int Settings::DEFAULT_DVR_DUPDETECT = DVR_AUTOREC_RECORD_ALL;
 const bool Settings::DEFAULT_DVR_PLAYSTATUS = true;
 const int Settings::DEFAULT_STREAM_CHUNKSIZE = 64; // KB


### PR DESCRIPTION
The pvr.hts addon timer setting for the dvr lifetime defaults to 3 months. As it overwrites the TVH backend settings and is not synchronized with it, it can lead to unintentional data loss. This PR changes the default setting to forever. It provides a workaround, for issue #458 until addon and backend settings can be synchronized. 