### PR TITLE
v7.1.0: Change default value for 'recordings lifetime' setting

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="7.0.1"
+  version="7.1.0"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,10 @@
+7.1.0
+- Add new setting value for recordings lifetime of timers created by Kodi: 'Use backend setting"
+- Change default value for 'lifetime' setting from '3 months' to 'Use backend setting' to
+  avoid unintended loss of data
+- Enforce reset of default value for lifetime' to 'Use backend setting' to avoid unintended loss
+  of data for existing addon configurations
+
 7.0.1
 - Fix hang during addon stop
 

--- a/pvr.hts/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hts/resources/language/resource.language.en_gb/strings.po
@@ -382,7 +382,12 @@ msgctxt "#30389"
 msgid "Forever (tvh 4.1+)"
 msgstr ""
 
-#empty strings from id 30390 to 30399
+#. Recording lifetime representation
+msgctxt "#30390"
+msgid "Use backend setting"
+msgstr ""
+
+#empty strings from id 30391 to 30399
 
 msgctxt "#30400"
 msgid "Predictive tuning"

--- a/pvr.hts/resources/settings.xml
+++ b/pvr.hts/resources/settings.xml
@@ -202,7 +202,7 @@
         </setting>
         <setting id="dvr_lifetime" type="integer" label="30056" help="-1">
           <level>0</level>
-          <default>8</default> <!-- 3 months -->
+          <default>15</default> <!-- Use backend setting -->
           <constraints>
             <options>
               <option label="30375">0</option> <!-- 1 day -->

--- a/pvr.hts/resources/settings.xml
+++ b/pvr.hts/resources/settings.xml
@@ -200,7 +200,7 @@
           </constraints>
           <control type="spinner" format="string" />
         </setting>
-        <setting id="dvr_lifetime" type="integer" label="30056" help="-1">
+        <setting id="dvr_lifetime2" type="integer" label="30056" help="-1">
           <level>0</level>
           <default>15</default> <!-- Use backend setting -->
           <constraints>

--- a/pvr.hts/resources/settings.xml
+++ b/pvr.hts/resources/settings.xml
@@ -220,6 +220,7 @@
               <option label="30387">12</option> <!-- 3 years -->
               <option label="30388">13</option> <!-- Until space needed (tvh 4.1+) -->
               <option label="30389">14</option> <!-- Forever (tvh 4.1+) -->
+              <option label="30390">15</option> <!-- Use backend setting -->
             </options>
           </constraints>
           <control type="spinner" format="string" />

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -766,6 +766,7 @@ struct TimerType : kodi::addon::PVRTimerType
 void CTvheadend::GetLivetimeValues(std::vector<kodi::addon::PVRTypeIntValue>& lifetimeValues) const
 {
   lifetimeValues = {
+      {LifetimeMapper::TvhToKodi(DVR_RET_DVRCONFIG), kodi::GetLocalizedString(30390)},
       {LifetimeMapper::TvhToKodi(DVR_RET_1DAY), kodi::GetLocalizedString(30375)},
       {LifetimeMapper::TvhToKodi(DVR_RET_3DAY), kodi::GetLocalizedString(30376)},
       {LifetimeMapper::TvhToKodi(DVR_RET_5DAY), kodi::GetLocalizedString(30377)},

--- a/src/tvheadend/Settings.cpp
+++ b/src/tvheadend/Settings.cpp
@@ -261,8 +261,11 @@ int Settings::GetDvrLifetime(bool asEnum) const
         return DVR_RET_3YEARS;
       case 13:
         return DVR_RET_SPACE;
-      default:
+      case 14:
         return DVR_RET_FOREVER;
+      case 15:
+      default:
+        return DVR_RET_DVRCONFIG;
     }
   }
 }

--- a/src/tvheadend/Settings.cpp
+++ b/src/tvheadend/Settings.cpp
@@ -76,7 +76,7 @@ void Settings::ReadSettings()
 
   /* Default dvr settings */
   SetDvrPriority(ReadIntSetting("dvr_priority", DEFAULT_DVR_PRIO));
-  SetDvrLifetime(ReadIntSetting("dvr_lifetime", DEFAULT_DVR_LIFETIME));
+  SetDvrLifetime(ReadIntSetting("dvr_lifetime2", DEFAULT_DVR_LIFETIME));
   SetDvrDupdetect(ReadIntSetting("dvr_dubdetect", DEFAULT_DVR_DUPDETECT));
 
   /* Sever based play status */
@@ -155,7 +155,7 @@ ADDON_STATUS Settings::SetSetting(const std::string& key, const kodi::CSettingVa
   /* Default dvr settings */
   else if (key == "dvr_priority")
     return SetIntSetting(GetDvrPriority(), value);
-  else if (key == "dvr_lifetime")
+  else if (key == "dvr_lifetime2")
     return SetIntSetting(GetDvrLifetime(true), value);
   else if (key == "dvr_dubdetect")
     return SetIntSetting(GetDvrDupdetect(), value);

--- a/src/tvheadend/Settings.cpp
+++ b/src/tvheadend/Settings.cpp
@@ -35,7 +35,7 @@ const int Settings::DEFAULT_APPROX_TIME =
     0; // don't use an approximate start time, use a fixed time instead for auto recordings
 const std::string Settings::DEFAULT_STREAMING_PROFILE = "";
 const int Settings::DEFAULT_DVR_PRIO = DVR_PRIO_NORMAL;
-const int Settings::DEFAULT_DVR_LIFETIME = 8; // enum 8 = 3 months
+const int Settings::DEFAULT_DVR_LIFETIME = 15; // use backend setting
 const int Settings::DEFAULT_DVR_DUPDETECT = DVR_AUTOREC_RECORD_ALL;
 const bool Settings::DEFAULT_DVR_PLAYSTATUS = true;
 const int Settings::DEFAULT_STREAM_CHUNKSIZE = 64; // KB

--- a/src/tvheadend/Settings.h
+++ b/src/tvheadend/Settings.h
@@ -44,7 +44,7 @@ public:
       DEFAULT_APPROX_TIME; // 0..1 (0 = use a fixed start time, 1 = use an approximate start time for auto recordings)
   static const std::string DEFAULT_STREAMING_PROFILE;
   static const int DEFAULT_DVR_PRIO; // any dvr_prio_t numeric value
-  static const int DEFAULT_DVR_LIFETIME; // 0..14 (0 = 1 day, 14 = forever)
+  static const int DEFAULT_DVR_LIFETIME; // 0..15 (0 = 1 day, 15 = use backend setting)
   static const int DEFAULT_DVR_DUPDETECT; // 0..5  (0 = record all, 5 = limit to once a day)
   static const bool DEFAULT_DVR_PLAYSTATUS;
   static const int DEFAULT_STREAM_CHUNKSIZE; // KB

--- a/src/tvheadend/utilities/LifetimeMapper.h
+++ b/src/tvheadend/utilities/LifetimeMapper.h
@@ -24,7 +24,9 @@ public:
   static int TvhToKodi(uint32_t tvhLifetime)
   {
     // pvr addon api: addon defined special values must be less than zero
-    if (tvhLifetime == DVR_RET_SPACE)
+    if (tvhLifetime == DVR_RET_DVRCONFIG)
+      return -3;
+    else if (tvhLifetime == DVR_RET_SPACE)
       return -2;
     else if (tvhLifetime == DVR_RET_FOREVER)
       return -1;
@@ -34,7 +36,9 @@ public:
 
   static uint32_t KodiToTvh(int kodiLifetime)
   {
-    if (kodiLifetime == -2)
+    if (kodiLifetime == -3)
+      return DVR_RET_DVRCONFIG;
+    else if (kodiLifetime == -2)
       return DVR_RET_SPACE;
     else if (kodiLifetime == -1)
       return DVR_RET_FOREVER;


### PR DESCRIPTION
- Add new setting value for recordings lifetime of timers created by Kodi: 'Use backend setting"
- Change default value for 'lifetime' setting from '3 months' to 'Use backend setting' to avoid unintended loss of data.
- Enforce reset of default value for lifetime' to 'Use backend setting' to avoid unintended loss of data for existing addon configurations

As discussed here: https://github.com/kodi-pvr/pvr.hts/issues/458

@m4tt075 mind doing a runtime-test?
