### PR TITLE
7.1.1: Fix 'provider name' and 'device status' signal status values after update to PVR API 7.0.0

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="7.1.0"
+  version="7.1.1"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+7.1.1
+- Fix 'provider name' and 'device status' signal status values after update to PVR API 7.0.0
+
 7.1.0
 - Add new setting value for recordings lifetime of timers created by Kodi: 'Use backend setting"
 - Change default value for 'lifetime' setting from '3 months' to 'Use backend setting' to

--- a/src/tvheadend/HTSPDemuxer.cpp
+++ b/src/tvheadend/HTSPDemuxer.cpp
@@ -257,8 +257,10 @@ PVR_ERROR HTSPDemuxer::CurrentSignal(kodi::addon::PVRSignalStatus& sig)
 
   sig.SetAdapterName(m_sourceInfo.si_adapter);
   sig.SetServiceName(m_sourceInfo.si_service);
+  sig.SetProviderName(m_sourceInfo.si_provider);
   sig.SetMuxName(m_sourceInfo.si_mux);
 
+  sig.SetAdapterStatus(m_signalInfo.fe_status);
   sig.SetSNR(m_signalInfo.fe_snr);
   sig.SetSignal(m_signalInfo.fe_signal);
   sig.SetBER(m_signalInfo.fe_ber);


### PR DESCRIPTION
Fixes fallout from #455 

Before:
![screenshot000](https://user-images.githubusercontent.com/3226626/86972801-ca70a080-c173-11ea-974d-830f56600ff9.png)

After:
![screenshot002](https://user-images.githubusercontent.com/3226626/86972810-cf355480-c173-11ea-83f7-706689b8b76a.png)
