### PR TITLE
increase 'getDiskSpace' timeout

### DIFF
--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -121,7 +121,7 @@ PVR_ERROR CTvheadend::GetDriveSpace(uint64_t& total, uint64_t& used)
   CLockObject lock(m_conn->Mutex());
 
   htsmsg_t* m = htsmsg_create_map();
-  m = m_conn->SendAndWait("getDiskSpace", m);
+  m = m_conn->SendAndWait("getDiskSpace", m, std::max(30000, Settings::GetInstance().GetResponseTimeout()));
   if (!m)
     return PVR_ERROR_SERVER_ERROR;
 


### PR DESCRIPTION
I encountered very frequent UI freezes in Kodi with the HTS addon on LibreELEC Raspberry Pi 1 related to timeouts of the `getDiskSpace` method.

Every time a UI freeze occurred, I found:
```
ERROR: AddOnLog: Tvheadend HTSP Client: pvr.hts - Command getDiskSpace failed: No response received
ERROR: GetDriveSpace: Add-on 'Tvheadend:omv.local:9982' returned an error: server error
ERROR: AddOnLog: Tvheadend HTSP Client: pvr.hts - failed to read packet (Bad file descriptor)
ERROR: GetTimers: Add-on 'Tvheadend:omv.local:9982' returned an error: the command failed
ERROR: GetTimers: PVR client 'Tvheadend:omv.local:9982' returned an error: the command failed
```
in the `kodi.log`.

Increasing the timeout for `getDiskSpace` prevents these error messages and further the UI freezes. I think this is just related to the less powerful Raspberry Pi 1 hardware and the resulting longer processing times. I still feel that increasing the timeout is just a workaround. Ideally, the plugin should call `getDiskSpace` asynchronously and update the disk space once a response has been received. Locking the UI because no response has been received is not a real option.

Fixes https://github.com/kodi-pvr/pvr.hts/issues/465.