### PR TITLE
7.1.2: Fix deadlock while reconnecting to backend after a backend response timeout

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="7.1.1"
+  version="7.1.2"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+7.1.2
+- Fix deadlock while reconnecting to backend after a backend response timeout (Fixes #465)
+
 7.1.1
 - Fix 'provider name' and 'device status' signal status values after update to PVR API 7.0.0
 


### PR DESCRIPTION
Fixes #465 

Cause of the UI freeze is a deadlock in pvr.hts, which is fixed by this PR.

Thread 27
* has tvh mtx -> CTvheadend::Process()
* wants connection mtx -> HTSPConnection::GetProtocol()

Thread 35
* has connection mtx -> HTSPConnection::Register()
* wants tvh mtx -> CTvheadend::Connected()


```
Thread 27 (Thread 0x64050380 (LWP 320)):
#0  __lll_lock_wait (futex=0x72e66390, private=0) at lowlevellock.c:43
#1  0x76eaadcc in __GI___pthread_mutex_lock (mutex=0x72e66390) at pthread_mutex_lock.c:115
#2  0x76d8c534 in P8PLATFORM::CMutex::Lock() () from /usr/lib/libcec.so.4
#3  0x683426dc in tvheadend::HTSPConnection::GetProtocol() const () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#4  0x68337508 in CTvheadend::ParseEvent(htsmsg*, bool, tvheadend::entity::Event&) () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#5  0x683382f0 in CTvheadend::ParseEventAddOrUpdate(htsmsg*, bool) () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#6  0x6833c028 in CTvheadend::Process() () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#7  0x76d8c6e8 in P8PLATFORM::CThread::ThreadHandler(void*) () from /usr/lib/libcec.so.4
#8  0x76ea83cc in start_thread (arg=0x64050380) at pthread_create.c:486
#9  0x74da48d8 in ?? () at ../sysdeps/unix/sysv/linux/arm/clone.S:73 from /usr/lib/libc.so.6
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

Thread 35 (Thread 0x5fbfb380 (LWP 331)):
#0  __lll_lock_wait (futex=0x72e693c0, private=0) at lowlevellock.c:46
#1  0x76eaadcc in __GI___pthread_mutex_lock (mutex=0x72e693c0) at pthread_mutex_lock.c:115
#2  0x76d8c534 in P8PLATFORM::CMutex::Lock() () from /usr/lib/libcec.so.4
#3  0x683353a4 in CTvheadend::Connected() () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#4  0x68343f48 in tvheadend::HTSPConnection::Register() () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#5  0x68344bd0 in tvheadend::HTSPConnection::HTSPRegister::Process() () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#6  0x76d8c6e8 in P8PLATFORM::CThread::ThreadHandler(void*) () from /usr/lib/libcec.so.4
#7  0x76ea83cc in start_thread (arg=0x5fbfb380) at pthread_create.c:486
#8  0x74da48d8 in ?? () at ../sysdeps/unix/sysv/linux/arm/clone.S:73 from /usr/lib/libc.so.6
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
```