### PR TITLE
7.1.4: HTSP connection related fixes and cleanup

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="7.1.3"
+  version="7.1.4"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+7.1.4
+- Fix deadlock while reconnecting to backend after a backend response timeout (Fixes #465)
+
 7.1.3
 - Withdraw v7.1.2 due to new deadlocks it introduces, for example during initial connect to backend.
 

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,5 +1,6 @@
 7.1.4
 - Fix deadlock while reconnecting to backend after a backend response timeout (Fixes #465)
+- Refactor subscription seek code
 
 7.1.3
 - Withdraw v7.1.2 due to new deadlocks it introduces, for example during initial connect to backend.

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -2,6 +2,7 @@
 - Fix deadlock while reconnecting to backend after a backend response timeout (Fixes #465)
 - Refactor subscription seek code
 - Refactor subscription weight code
+- Fix HTSP connection thread not ended while in supended state
 
 7.1.3
 - Withdraw v7.1.2 due to new deadlocks it introduces, for example during initial connect to backend.

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,6 +1,7 @@
 7.1.4
 - Fix deadlock while reconnecting to backend after a backend response timeout (Fixes #465)
 - Refactor subscription seek code
+- Refactor subscription weight code
 
 7.1.3
 - Withdraw v7.1.2 due to new deadlocks it introduces, for example during initial connect to backend.

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -174,6 +174,7 @@ private:
   /*
    * Channel/Tags/Recordings/Events
    */
+  void SyncInitCompleted();
   void SyncChannelsCompleted();
   void SyncDvrCompleted();
   void SyncEpgCompleted();

--- a/src/tvheadend/AutoRecordings.cpp
+++ b/src/tvheadend/AutoRecordings.cpp
@@ -31,7 +31,7 @@ AutoRecordings::~AutoRecordings()
 {
 }
 
-void AutoRecordings::Connected()
+void AutoRecordings::RebuildState()
 {
   /* Flag all async fields in case they've been deleted */
   for (auto& rec : m_autoRecordings)

--- a/src/tvheadend/AutoRecordings.h
+++ b/src/tvheadend/AutoRecordings.h
@@ -33,7 +33,7 @@ public:
   ~AutoRecordings();
 
   /* state updates */
-  void Connected();
+  void RebuildState();
   void SyncDvrCompleted();
 
   /* data access */

--- a/src/tvheadend/HTSPConnection.cpp
+++ b/src/tvheadend/HTSPConnection.cpp
@@ -645,13 +645,14 @@ void* HTSPConnection::Process()
       }
     }
 
-    while (m_suspended)
+    while (m_suspended && !IsStopped())
     {
-      Logger::Log(LogLevel::LEVEL_DEBUG, "suspended. Waiting for wakeup...");
-
       /* Wait for wakeup */
       Sleep(1000);
     }
+
+    if (IsStopped())
+      break;
 
     if (!log)
     {
@@ -691,6 +692,7 @@ void* HTSPConnection::Process()
 
       continue;
     }
+
     Logger::Log(LogLevel::LEVEL_DEBUG, "connected");
     log = false;
     retryAttempt = 0;

--- a/src/tvheadend/HTSPDemuxer.cpp
+++ b/src/tvheadend/HTSPDemuxer.cpp
@@ -269,6 +269,8 @@ void HTSPDemuxer::FillBuffer(bool mode)
 
 void HTSPDemuxer::Weight(enum eSubscriptionWeight weight)
 {
+  CLockObject lock(m_conn.Mutex());
+
   if (!m_subscription.IsActive() || m_subscription.GetWeight() == static_cast<uint32_t>(weight))
     return;
 

--- a/src/tvheadend/HTSPDemuxer.cpp
+++ b/src/tvheadend/HTSPDemuxer.cpp
@@ -49,12 +49,14 @@ HTSPDemuxer::~HTSPDemuxer()
 {
 }
 
-void HTSPDemuxer::Connected()
+void HTSPDemuxer::RebuildState()
 {
   /* Re-subscribe */
   if (m_subscription.IsActive())
   {
     Logger::Log(LogLevel::LEVEL_DEBUG, "demux re-starting stream");
+
+    CLockObject lock(m_conn.Mutex());
     m_subscription.SendSubscribe(0, 0, true);
     m_subscription.SendSpeed(0, true);
 

--- a/src/tvheadend/HTSPDemuxer.cpp
+++ b/src/tvheadend/HTSPDemuxer.cpp
@@ -35,8 +35,7 @@ using namespace tvheadend::utilities;
 HTSPDemuxer::HTSPDemuxer(IHTSPDemuxPacketHandler& demuxPktHdl, HTSPConnection& conn)
   : m_conn(conn),
     m_pktBuffer(static_cast<size_t>(-1)),
-    m_seekTime(INVALID_SEEKTIME),
-    m_seeking(false),
+    m_seektime(nullptr),
     m_subscription(conn),
     m_lastUse(0),
     m_startTime(0),
@@ -85,7 +84,7 @@ void HTSPDemuxer::Abort0()
   m_streams.clear();
   m_streamStat.clear();
   m_rdsIdx = 0;
-  m_seeking = false;
+  m_seektime = nullptr;
 }
 
 
@@ -166,36 +165,68 @@ void HTSPDemuxer::Abort()
   ResetStatus();
 }
 
+namespace tvheadend
+{
+
+class SubscriptionSeekTime
+{
+public:
+  SubscriptionSeekTime() = default;
+
+  ~SubscriptionSeekTime()
+  {
+    Set(INVALID_SEEKTIME); // ensure signal is sent
+  }
+
+  int64_t Get(CMutex& mutex, uint32_t timeout)
+  {
+    m_cond.Wait(mutex, m_flag, timeout);
+    m_flag = false;
+    return m_seektime;
+  }
+
+  void Set(int64_t seektime)
+  {
+    m_seektime = seektime;
+    m_flag = true;
+    m_cond.Broadcast();
+  }
+
+private:
+  CCondition<volatile bool> m_cond;
+  bool m_flag = false;
+  int64_t m_seektime = INVALID_SEEKTIME;
+};
+
+} // namespace tvheadend
+
 bool HTSPDemuxer::Seek(double time, bool, double& startpts)
 {
+  CLockObject lock(m_conn.Mutex());
+
   if (!m_subscription.IsActive())
     return false;
 
-  m_seekTime = 0;
-  m_seeking = true;
+  SubscriptionSeekTime seekTime;
+  m_seektime = &seekTime;
+
   if (!m_subscription.SendSeek(time))
-  {
-    m_seeking = false;
     return false;
-  }
 
   /* Wait for time */
-  CLockObject lock(m_conn.Mutex());
+  int64_t seekedTo =
+      (*m_seektime).Get(m_conn.Mutex(), Settings::GetInstance().GetResponseTimeout());
+  m_seektime = nullptr;
 
-  if (!m_seekCond.Wait(m_conn.Mutex(), m_seekTime, Settings::GetInstance().GetResponseTimeout()))
+  if (seekedTo == INVALID_SEEKTIME)
   {
     Logger::Log(LogLevel::LEVEL_ERROR, "failed to get subscriptionSeek response");
-    m_seeking = false;
     Flush(); /* try to resync */
     return false;
   }
 
-  m_seeking = false;
-  if (m_seekTime == INVALID_SEEKTIME)
-    return false;
-
   /* Store */
-  startpts = TVH_TO_DVD_TIME(m_seekTime - 1);
+  startpts = TVH_TO_DVD_TIME(seekedTo);
   Logger::Log(LogLevel::LEVEL_TRACE, "demux seek startpts = %lf", startpts);
 
   return true;
@@ -526,7 +557,7 @@ void HTSPDemuxer::ParseMuxPacket(htsmsg_t* m)
   if (!type)
     type = '_';
 
-  bool ignore = m_seeking;
+  bool ignore = m_seektime != nullptr;
 
   Logger::Log(LogLevel::LEVEL_TRACE, "demux pkt idx %d:%d type %c pts %lf len %lld%s", idx,
               pkt->iStreamId, type, pkt->pts, static_cast<long long>(binlen),
@@ -792,25 +823,25 @@ void HTSPDemuxer::ParseSourceInfo(htsmsg_t* m)
 
 void HTSPDemuxer::ParseSubscriptionStop(htsmsg_t*)
 {
-  //CLockObject lock(m_mutex);
 }
 
 void HTSPDemuxer::ParseSubscriptionSkip(htsmsg_t* m)
 {
   CLockObject lock(m_conn.Mutex());
 
+  if (m_seektime == nullptr)
+    return;
+
   int64_t s64 = 0;
   if (htsmsg_get_s64(m, "time", &s64))
   {
-    m_seekTime = INVALID_SEEKTIME;
+    (*m_seektime).Set(INVALID_SEEKTIME);
   }
   else
   {
-    m_seekTime = s64 < 0 ? 1 : s64 + 1; /* it must not be zero! */
+    (*m_seektime).Set(s64 < 0 ? 0 : s64);
     Flush(); /* flush old packets (with wrong pts) */
   }
-  m_seeking = false;
-  m_seekCond.Broadcast();
 }
 
 void HTSPDemuxer::ParseSubscriptionSpeed(htsmsg_t* m)

--- a/src/tvheadend/HTSPDemuxer.h
+++ b/src/tvheadend/HTSPDemuxer.h
@@ -35,6 +35,7 @@ namespace tvheadend
 {
 
 class HTSPConnection;
+class SubscriptionSeekTime;
 
 /*
  * HTSP Demuxer - live streams
@@ -110,9 +111,7 @@ private:
   P8PLATFORM::SyncedBuffer<DemuxPacket*> m_pktBuffer;
   std::vector<kodi::addon::PVRStreamProperties> m_streams;
   std::map<int, int> m_streamStat;
-  int64_t m_seekTime;
-  P8PLATFORM::CCondition<volatile int64_t> m_seekCond;
-  bool m_seeking;
+  std::atomic<SubscriptionSeekTime*> m_seektime;
   tvheadend::status::SourceInfo m_sourceInfo;
   tvheadend::status::Quality m_signalInfo;
   tvheadend::status::TimeshiftStatus m_timeshiftStatus;

--- a/src/tvheadend/HTSPDemuxer.h
+++ b/src/tvheadend/HTSPDemuxer.h
@@ -46,7 +46,7 @@ public:
   ~HTSPDemuxer();
 
   bool ProcessMessage(const std::string& method, htsmsg_t* m);
-  void Connected();
+  void RebuildState();
 
   bool Open(uint32_t channelId,
             tvheadend::eSubscriptionWeight weight = tvheadend::SUBSCRIPTION_WEIGHT_NORMAL);

--- a/src/tvheadend/HTSPVFS.cpp
+++ b/src/tvheadend/HTSPVFS.cpp
@@ -47,7 +47,7 @@ HTSPVFS::~HTSPVFS()
 {
 }
 
-void HTSPVFS::Connected()
+void HTSPVFS::RebuildState()
 {
   /* Re-open */
   if (m_fileId != 0)

--- a/src/tvheadend/HTSPVFS.h
+++ b/src/tvheadend/HTSPVFS.h
@@ -34,7 +34,7 @@ public:
   HTSPVFS(HTSPConnection& conn);
   ~HTSPVFS();
 
-  void Connected();
+  void RebuildState();
 
   bool Open(const kodi::addon::PVRRecording& rec);
   void Close();

--- a/src/tvheadend/Subscription.cpp
+++ b/src/tvheadend/Subscription.cpp
@@ -221,10 +221,7 @@ void Subscription::SendWeight(uint32_t weight)
   Logger::Log(LogLevel::LEVEL_DEBUG, "demux send weight %u", GetWeight());
 
   /* Send and Wait */
-  {
-    CLockObject lock(m_conn.Mutex());
-    m = m_conn.SendAndWait("subscriptionChangeWeight", m);
-  }
+  m = m_conn.SendAndWait("subscriptionChangeWeight", m);
   if (m)
     htsmsg_destroy(m);
 }

--- a/src/tvheadend/Subscription.cpp
+++ b/src/tvheadend/Subscription.cpp
@@ -180,17 +180,12 @@ bool Subscription::SendSeek(double time)
   Logger::Log(LogLevel::LEVEL_DEBUG, "demux send seek %d", time);
 
   /* Send and Wait */
-  {
-    CLockObject lock(m_conn.Mutex());
-    m = m_conn.SendAndWait("subscriptionSeek", m);
-  }
-  if (m)
-  {
-    htsmsg_destroy(m);
-    return true;
-  }
+  m = m_conn.SendAndWait("subscriptionSeek", m);
+  if (!m)
+    return false;
 
-  return false;
+  htsmsg_destroy(m);
+  return true;
 }
 
 void Subscription::SendSpeed(int32_t speed, bool restart)

--- a/src/tvheadend/TimeRecordings.cpp
+++ b/src/tvheadend/TimeRecordings.cpp
@@ -30,7 +30,7 @@ TimeRecordings::~TimeRecordings()
 {
 }
 
-void TimeRecordings::Connected()
+void TimeRecordings::RebuildState()
 {
   /* Flag all async fields in case they've been deleted */
   for (auto& rec : m_timeRecordings)

--- a/src/tvheadend/TimeRecordings.h
+++ b/src/tvheadend/TimeRecordings.h
@@ -33,7 +33,7 @@ public:
   ~TimeRecordings();
 
   /* state updates */
-  void Connected();
+  void RebuildState();
   void SyncDvrCompleted();
 
   /* data access */

--- a/src/tvheadend/utilities/AsyncState.h
+++ b/src/tvheadend/utilities/AsyncState.h
@@ -21,10 +21,11 @@ namespace utilities
 enum eAsyncState
 {
   ASYNC_NONE = 0,
-  ASYNC_CHN = 1,
-  ASYNC_DVR = 2,
-  ASYNC_EPG = 3,
-  ASYNC_DONE = 4
+  ASYNC_INIT = 1,
+  ASYNC_CHN = 2,
+  ASYNC_DVR = 3,
+  ASYNC_EPG = 4,
+  ASYNC_DONE = 5
 };
 
 /**


### PR DESCRIPTION
Fix deadlock while reconnecting to backend after a backend response timeout (Fixes #465). Second try....

Cause of the UI freeze is a deadlock in pvr.hts, which is fixed by this PR.

Thread 27

* has tvh mtx -> CTvheadend::Process()
* wants connection mtx -> HTSPConnection::GetProtocol()

Thread 35

* has connection mtx -> HTSPConnection::Register()
* wants tvh mtx -> CTvheadend::Connected()

```log
Thread 27 (Thread 0x64050380 (LWP 320)):
#0  __lll_lock_wait (futex=0x72e66390, private=0) at lowlevellock.c:43
#1  0x76eaadcc in __GI___pthread_mutex_lock (mutex=0x72e66390) at pthread_mutex_lock.c:115
#2  0x76d8c534 in P8PLATFORM::CMutex::Lock() () from /usr/lib/libcec.so.4
#3  0x683426dc in tvheadend::HTSPConnection::GetProtocol() const () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#4  0x68337508 in CTvheadend::ParseEvent(htsmsg*, bool, tvheadend::entity::Event&) () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#5  0x683382f0 in CTvheadend::ParseEventAddOrUpdate(htsmsg*, bool) () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#6  0x6833c028 in CTvheadend::Process() () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#7  0x76d8c6e8 in P8PLATFORM::CThread::ThreadHandler(void*) () from /usr/lib/libcec.so.4
#8  0x76ea83cc in start_thread (arg=0x64050380) at pthread_create.c:486
#9  0x74da48d8 in ?? () at ../sysdeps/unix/sysv/linux/arm/clone.S:73 from /usr/lib/libc.so.6
Backtrace stopped: previous frame identical to this frame (corrupt stack?)

Thread 35 (Thread 0x5fbfb380 (LWP 331)):
#0  __lll_lock_wait (futex=0x72e693c0, private=0) at lowlevellock.c:46
#1  0x76eaadcc in __GI___pthread_mutex_lock (mutex=0x72e693c0) at pthread_mutex_lock.c:115
#2  0x76d8c534 in P8PLATFORM::CMutex::Lock() () from /usr/lib/libcec.so.4
#3  0x683353a4 in CTvheadend::Connected() () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#4  0x68343f48 in tvheadend::HTSPConnection::Register() () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#5  0x68344bd0 in tvheadend::HTSPConnection::HTSPRegister::Process() () from /storage/.kodi/addons/pvr.hts/pvr.hts.so.4.4.21
#6  0x76d8c6e8 in P8PLATFORM::CThread::ThreadHandler(void*) () from /usr/lib/libcec.so.4
#7  0x76ea83cc in start_thread (arg=0x5fbfb380) at pthread_create.c:486
#8  0x74da48d8 in ?? () at ../sysdeps/unix/sysv/linux/arm/clone.S:73 from /usr/lib/libc.so.6
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
```