### PR TITLE
7.2.2: Fix toggling of HTTP streaming setting

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="7.2.1"
+  version="7.2.2"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+7.2.2
+- Fix toggling of HTTP streaming setting
+
 7.2.1
 - Fix 'pvr.hts' appearing twice in every addon log message
 - Fix calculation of start time, stop time and file size for multi-file recordings

--- a/src/tvheadend/Settings.cpp
+++ b/src/tvheadend/Settings.cpp
@@ -154,6 +154,8 @@ ADDON_STATUS Settings::SetSetting(const std::string& key, const kodi::CSettingVa
   /* Streaming */
   else if (key == "streaming_profile")
     return SetStringSetting(GetStreamingProfile(), value);
+  else if (key == "streaming_http")
+    return SetBoolSetting(GetStreamingHTTP(), value);
   /* Default dvr settings */
   else if (key == "dvr_priority")
     return SetIntSetting(GetDvrPriority(), value);


### PR DESCRIPTION
The HTTP Streaming toggle button in the addon settings does not take effect immediately after toggling the setting.

A change to this setting only takes effect after you either (for example) disable/re-enable the addon, or restart kodi.

You can confirm this by checking in the Status area of the Tvheadend admin interface after toggling this setting and playing a channel:
![image](https://user-images.githubusercontent.com/14977362/96886793-d3b01f80-147b-11eb-8b89-502cf75118c9.png)

In this case I had ticked the box to use HTTP Streaming, but the htsp protocol was still being used instead.

Looking in the code it looks like #476 missed adding a line to Settings::SetSetting in src/tvheadend/Settings.cpp