### PR TITLE
8.1.3: Fix: Error handling for socket read/write operations.

### DIFF
--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -2,6 +2,7 @@
 - Fix: Obtain streaming profiles as soon as connected to backend
 - Fix: On system sleep, properly close demuxers before disconnecting from backend
 - Fix: Predictive Tuning: Prevent closing the subscription while re-subscribing to it
+- Fix: Error handling for socket read/write operations
 
 8.1.2
 - More IPv6 fixes

--- a/src/tvheadend/utilities/TCPSocket.cpp
+++ b/src/tvheadend/utilities/TCPSocket.cpp
@@ -97,7 +97,7 @@ void TCPSocket::Close()
 int64_t TCPSocket::Read(void* data, size_t len, uint64_t iTimeoutMs /*= 0*/)
 {
   if (!m_socket)
-    return 0;
+    return -1;
 
   try
   {
@@ -154,14 +154,14 @@ int64_t TCPSocket::Read(void* data, size_t len, uint64_t iTimeoutMs /*= 0*/)
   }
   catch (std::runtime_error const&)
   {
-    return 0;
+    return -1;
   }
 }
 
 int64_t TCPSocket::Write(void* data, size_t len)
 {
   if (!m_socket)
-    return 0;
+    return -1;
 
   try
   {
@@ -170,6 +170,6 @@ int64_t TCPSocket::Write(void* data, size_t len)
   }
   catch (std::runtime_error const&)
   {
-    return 0;
+    return -1;
   }
 }


### PR DESCRIPTION
Forgot to add this commit to #486. Sorry. This is needed for proper reconnect after network outage.