### PR TITLE
PVR API 7.1.0 - API change to allow epg max future and past days

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="8.1.3"
+  version="8.2.0"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+8.2.0
+- PVR API 7.1.0 - API change to allow epg max future and past days
+
 8.1.3
 - Fix: Obtain streaming profiles as soon as connected to backend
 - Fix: On system sleep, properly close demuxers before disconnecting from backend
@@ -350,7 +353,7 @@
 - fixed duplicate 'prevent duplicate episodes' timer settings values
 
 4.0.6
-- added HTSP v26 support 
+- added HTSP v26 support
 - added server based playstatus for recordings (HTSP v26 and up)
 
 4.0.5
@@ -429,7 +432,7 @@
 - fixed: potential crash in connection state change callback
 
 3.2.1
-- fixed: lifetime 'forever' should be disabled for HTSP v24 and lower 
+- fixed: lifetime 'forever' should be disabled for HTSP v24 and lower
 - improved: make lifetime settings translatable
 
 3.2.0
@@ -456,7 +459,7 @@
 
 2.2.10
 - updated language files from Transifex
-- fixed: approximate start time setting 
+- fixed: approximate start time setting
 - fixed: invalid addon restart when closing the settings dialog
 - improved: limit the amount of timer lifetime values
 - improved: separate timer and streaming settings
@@ -652,7 +655,7 @@
 1.6.16
 
 - correct some signed/unsigned mixups
-- added imagecache support (icons on the backend) 
+- added imagecache support (icons on the backend)
 
 1.6.15
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -38,7 +38,7 @@ CTvheadend::CTvheadend(KODI_HANDLE instance, const std::string& kodiVersion)
     m_asyncState(Settings::GetInstance().GetResponseTimeout()),
     m_timeRecordings(*m_conn),
     m_autoRecordings(*m_conn),
-    m_epgMaxDays(EpgMaxDays()),
+    m_epgMaxDays(EpgMaxFutureDays()),
     m_playingLiveStream(false),
     m_playingRecording(nullptr)
 {
@@ -1488,17 +1488,18 @@ PVR_ERROR CTvheadend::GetEPGForChannel(int channelUid,
   return PVR_ERROR_NO_ERROR;
 }
 
-PVR_ERROR CTvheadend::SetEPGTimeFrame(int iDays)
+PVR_ERROR CTvheadend::SetEPGMaxFutureDays(int iFutureDays)
 {
-  if (m_epgMaxDays != iDays)
+  if (m_epgMaxDays != iFutureDays)
   {
-    m_epgMaxDays = iDays;
+    int iOldMaxDays = m_epgMaxDays;
+    m_epgMaxDays = iFutureDays;
 
     if (Settings::GetInstance().GetAsyncEpg())
     {
       Logger::Log(LogLevel::LEVEL_TRACE,
                   "reconnecting to synchronize epg data. epg max time: old = %d, new = %d",
-                  m_epgMaxDays, iDays);
+                  iOldMaxDays, iFutureDays);
       m_conn->Disconnect(); // reconnect to synchronize epg data
     }
   }

--- a/src/Tvheadend.h
+++ b/src/Tvheadend.h
@@ -118,7 +118,7 @@ public:
                              time_t start,
                              time_t end,
                              kodi::addon::PVREPGTagsResultSet& results) override;
-  PVR_ERROR SetEPGTimeFrame(int days) override;
+  PVR_ERROR SetEPGMaxFutureDays(int futureDays) override;
 
   void GetLivetimeValues(std::vector<kodi::addon::PVRTypeIntValue>& lifetimeValues) const;
 


### PR DESCRIPTION
8.2.0
- PVR API 7.1.0 - API change to allow epg max future and past days

Not to be merged until xbmc/xbmc#19035 is merged.