### PR TITLE
8.2.2: Fix: kissnet update fixing Windows socket connection issue

### DIFF
--- a/lib/kissnet/kissnet.hpp
+++ b/lib/kissnet/kissnet.hpp
@@ -735,7 +735,7 @@ namespace kissnet
 				if (error == SOCKET_ERROR)
 				{
 					error = get_error_code();
-					if (error == EAGAIN || error == EINPROGRESS)
+					if (error == EWOULDBLOCK || error == EAGAIN || error == EINPROGRESS)
 					{
 						struct timeval tv;
 						tv.tv_sec = static_cast<long>(timeout / 1000);

--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="8.2.1"
+  version="8.2.2"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+8.2.2
+- Fix: kissnet update fixing Windows socket connection issue
+
 8.2.1
 - Fix: kissnet update fixing socket creation/connection issue
 


### PR DESCRIPTION
Fixes a regression that slipped in with latest kissnet update. That regression prevented connecting to tvh backend on Windows. :-/

Fixed runtime-tested and confirmed working by @howie-f