### PR TITLE
8.2.4: Fix broken string in en_gb language file.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="8.2.3"
+  version="8.2.4"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+8.2.4
+- Fix: broken string in en_gb resource file.
+
 8.2.3
 - Usability: Change settings spinners to selection lists
 - Fixed: Timer settings: Add missing duplicate detection values

--- a/pvr.hts/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hts/resources/language/resource.language.en_gb/strings.po
@@ -64,7 +64,7 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Use HTTPS"
-msgstr "Use HTTPS"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Server MAC for Wake-on-LAN"


### PR DESCRIPTION
See https://github.com/kodi-pvr/pvr.hts/pull/499#discussion_r593876834 ff.