### PR TITLE
8.3.1: Fix: Demuxer must reset start time when reconnecting

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="8.3.0"
+  version="8.3.1"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+8.3.1
+- Fix: Demuxer must reset start time when reconnecting
+
 8.3.0
 - New setting: Regular expression vs. 'contains' search for Autorecs.
 
@@ -6,7 +9,7 @@
 
 8.2.3
 - Usability: Change settings spinners to selection lists
-- Fixed: Timer settings: Add missing duplicate detection values
+- Fix: Timer settings: Add missing duplicate detection values
 
 8.2.2
 - Fix: kissnet update fixing Windows socket connection issue
@@ -34,7 +37,7 @@
 
 8.1.0
 - Update inputstream API 3.0.1
-  - Fix wrong flags bit shift
+- Fix wrong flags bit shift
 
 8.0.0
 - Update PVR API 7.0.2

--- a/src/tvheadend/HTSPDemuxer.cpp
+++ b/src/tvheadend/HTSPDemuxer.cpp
@@ -414,6 +414,7 @@ void HTSPDemuxer::ResetStatus(bool resetSubscriptionData /* = true */)
 {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
+  m_startTime = 0;
   m_signalInfo.Clear();
   m_descrambleInfo.Clear();
   m_timeshiftStatus.Clear();
@@ -421,7 +422,6 @@ void HTSPDemuxer::ResetStatus(bool resetSubscriptionData /* = true */)
   if (resetSubscriptionData)
   {
     m_sourceInfo.Clear(); // only send once with subscriptionStart response
-    m_startTime = 0;
   }
 }
 

--- a/src/tvheadend/HTSPDemuxer.h
+++ b/src/tvheadend/HTSPDemuxer.h
@@ -86,7 +86,7 @@ private:
 
   /**
    * Resets the signal, quality, timeshift info and optionally the starttime
-   * @param resetStartTime if true, all subscription-related data will be reset
+   * @param resetSubscriptionData if true, all subscription-related data will be reset
    */
   void ResetStatus(bool resetSubscriptionData = true);
 


### PR DESCRIPTION
Fixes broken timeshift visualization and control after a reconnect.