### PR TITLE
8.3.2: Demuxer: Only restart connection when not paused

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="8.3.1"
+  version="8.3.2"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+v8.3.2
+- Fixed: Timeshift issues after pausing and resuming Live TV (affects only demuxer-served channels).
+
 v8.3.1
 - Translations updates from Weblate
 	- af_za, am_et, ar_sa, az_az, be_by, bg_bg, bs_ba, ca_es, cs_cz, cy_gb, da_dk, de_de, el_gr, en_au, en_nz, en_us, eo, es_ar, es_es, es_mx, et_ee, eu_es, fa_af, fa_ir, fi_fi, fo_fo, fr_ca, fr_fr, gl_es, he_il, hi_in, hr_hr, hu_hu, hy_am, id_id, is_is, it_it, ja_jp, ko_kr, lt_lt, lv_lv, mi, mk_mk, ml_in, mn_mn, ms_my, mt_mt, my_mm, nb_no, nl_nl, pl_pl, pt_br, pt_pt, ro_ro, ru_ru, si_lk, sk_sk, sl_si, sq_al, sr_rs, sr_rs@latin, sv_se, szl, ta_in, te_in, tg_tj, th_th, tr_tr, uk_ua, uz_uz, vi_vn, zh_cn, zh_tw

--- a/src/tvheadend/HTSPDemuxer.cpp
+++ b/src/tvheadend/HTSPDemuxer.cpp
@@ -142,7 +142,7 @@ DEMUX_PACKET* HTSPDemuxer::Read()
   }
   Logger::Log(LogLevel::LEVEL_TRACE, "demux read nothing");
 
-  if (m_lastPkt > 0 && m_lastUse - m_lastPkt > 10)
+  if (m_lastPkt > 0 && m_lastUse - m_lastPkt > 10 && !IsPaused())
   {
     Logger::Log(LogLevel::LEVEL_WARNING,
                 "demux read no data for at least 10 secs; restarting connection");
@@ -256,7 +256,10 @@ void HTSPDemuxer::Speed(int speed)
     return;
 
   if (speed != 0)
-    speed = 1000;
+  {
+    speed = SPEED_NORMAL;
+    m_lastPkt = 0;
+  }
 
   if ((speed != m_requestedSpeed || speed == 0) && m_actualSpeed == m_subscription.GetSpeed())
   {
@@ -273,7 +276,7 @@ void HTSPDemuxer::FillBuffer(bool mode)
   if (!m_subscription.IsActive())
     return;
 
-  int speed = (!mode || IsRealTimeStream()) ? 1000 : 4000;
+  int speed = (!mode || IsRealTimeStream()) ? SPEED_NORMAL : 4 * SPEED_NORMAL;
 
   if (speed != m_requestedSpeed && m_actualSpeed == m_subscription.GetSpeed())
   {


### PR DESCRIPTION
Fixes an edge case with timeshifting after pausing and resuming Live TV.