### PR TITLE
8.3.4: Fixed 'Use HTTPS' setting init/write.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="8.3.3"
+  version="8.3.4"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+v8.3.4
+- Fixed 'Use HTTPS' setting init/write
+
 v8.3.3
 - Fixed: Crash while restarting the add-on (due to stale HTSP connection thread after unloading add-on's shared lib).
 

--- a/src/tvheadend/Settings.cpp
+++ b/src/tvheadend/Settings.cpp
@@ -49,6 +49,7 @@ void Settings::ReadSettings()
   SetHostname(ReadStringSetting("host", DEFAULT_HOST));
   SetPortHTSP(ReadIntSetting("htsp_port", DEFAULT_HTSP_PORT));
   SetPortHTTP(ReadIntSetting("http_port", DEFAULT_HTTP_PORT));
+  SetUseHTTPS(ReadBoolSetting("https", DEFAULT_USE_HTTPS));
   SetUsername(ReadStringSetting("user", DEFAULT_USERNAME));
   SetPassword(ReadStringSetting("pass", DEFAULT_PASSWORD));
   SetWolMac(ReadStringSetting("wol_mac", DEFAULT_WOL_MAC));
@@ -104,7 +105,7 @@ ADDON_STATUS Settings::SetSetting(const std::string& key, const kodi::CSettingVa
   else if (key == "http_port")
     return SetIntSetting(GetPortHTTP(), value);
   else if (key == "https")
-    return SetIntSetting(GetUseHTTPS(), value);
+    return SetBoolSetting(GetUseHTTPS(), value);
   else if (key == "user")
     return SetStringSetting(GetUsername(), value);
   else if (key == "pass")


### PR DESCRIPTION
Should fix #519.

Interestingly, this feature never could have worked. The related settings value never was read / set on add-on init, so HTTPS actually never was used.