### PR TITLE
Fix errors for sq_al language translations

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -116,7 +116,7 @@
     <description lang="ru_RU">Интерфейс для Tvheadend. Поддерживает просмотр и запись ТВ, EPG и таймеры</description>
     <description lang="sk_SK">Rozhranie pre Tvheadend; je podporované streamovanie živého televízneho vysielania a nahrávok, EPG, časovačov</description>
     <description lang="sl_SI">Vmesnik za Tvheadend; podpira pretakanje televizije v živo &amp; posnetkov, EPG, časovnike</description>
-    <description lang="sq_AL">Tvheadend frotnend përkrahën transmetimin e Live TV'së, EPG'së dhe "timer'ë"</description>
+    <description lang="sq_AL">Tvheadend frotnend përkrahën transmetimin e Live TV'së, EPG'së dhe &quot;timer'ë&quot;</description>
     <description lang="sr_RS">Tvheadend интерфејс; подржава стримовање ТВ Уживо &amp; Снимака, EPG, Тајмере</description>
     <description lang="sr_RS@latin">Tvheadend interfejs; podržava strimovanje TV Uživo &amp; Snimaka, EPG, Tajmere</description>
     <description lang="sv_SE">Tvheadend frontend; stödjer strömning av Live-TV &amp; inspelningar, EPG, Timers</description>

--- a/pvr.hts/resources/language/resource.language.sq_al/strings.po
+++ b/pvr.hts/resources/language/resource.language.sq_al/strings.po
@@ -22,7 +22,7 @@ msgstr "Frontend i Kodi'së për Tvheadend"
 
 msgctxt "Addon Description"
 msgid "Tvheadend frontend; supporting streaming of Live TV &amp; Recordings, EPG, Timers"
-msgstr "Tvheadend frotnend përkrahën transmetimin e Live TV'së, EPG'së dhe "timer'ë""
+msgstr "Tvheadend frotnend përkrahën transmetimin e Live TV'së, EPG'së dhe \"timer'ë\""
 
 # settings labels
 msgctxt "#30000"


### PR DESCRIPTION
This fixes errors for sq_al language:

- addon.xml.in: replace `"` with `&quot;`
- resource.language.sq_al/strings.po: replace `"` with `\"`