### PR TITLE
Fix AAC RDS parser.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="20.1.0"
+  version="20.1.1"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+v20.1.1
+- Fix AAC RDS parser
+
 v20.1.0
 - Kodi API to 8.0.0
   - Add supports recordings delete capability
@@ -5,11 +8,7 @@ v20.1.0
 
 v20.0.0
 - Translations updates from Weblate
-  - ko_kr
-- Changed test builds to 'Kodi 20 Nexus'
-- Increased version to 20.0.0
-  - With start of Kodi 20 Nexus, takes addon as major the same version number as Kodi.
-    This done to know easier to which Kodi the addon works.
+- Version numbering scheme change
 
 v8.4.0
 - Add support for RDS data contained in AAC streams.


### PR DESCRIPTION
Motivation: https://forum.kodi.tv/showthread.php?tid=336682&pid=3052210#pid3052210

This fixes support for RDS data for German radio channels from broadcasters NDR, MDR, BR (and maybe others) in Kodi.

Thanks one more time to @carsten-gross for figuring out the details.