### PR TITLE
Misc fixes

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="20.2.0"
+  version="20.2.1"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,12 @@
+v20.2.1
+- Ignore recordings without a file (e.g. removed recordings).
+- When parsing recording add/update messages, always set the correct error string.
+- Reduce debug log spam. Do not log recording descriptions.
+
+v20.2.0
+- Update translations
+- Adapt to recent API changes
+
 v20.1.2
 - Fix Unable to change existing timer rule to use any time
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -2602,8 +2602,8 @@ void CTvheadend::ParseRecordingAddOrUpdate(htsmsg_t* msg, bool bAdd)
       rec.SetState(PVR_TIMER_STATE_ABORTED);
     else if (strstr(str, "missing") != nullptr)
       rec.SetState(PVR_TIMER_STATE_ERROR);
-    else
-      rec.SetError(str);
+
+    rec.SetError(str);
   }
 
   /* A running recording will have an active subscription assigned to it */

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -2306,6 +2306,11 @@ void CTvheadend::ParseRecordingAddOrUpdate(htsmsg_t* msg, bool bAdd)
       !htsmsg_get_u32(msg, "duplicate", &dup) && dup == 1)
     return;
 
+  /* Ignore recordings without a file (e.g. removed recordings) */
+  const char* error = htsmsg_get_str(msg, "error");
+  if (error && (strstr(error, "missing") != nullptr))
+    return;
+
   /* Get/create entry */
   Recording& rec = m_recordings[id];
   Recording comparison = rec;
@@ -2595,15 +2600,12 @@ void CTvheadend::ParseRecordingAddOrUpdate(htsmsg_t* msg, bool bAdd)
   }
 
   /* Error */
-  str = htsmsg_get_str(msg, "error");
-  if (str)
+  if (error)
   {
-    if (!std::strcmp(str, "300"))
+    if (!std::strcmp(error, "300"))
       rec.SetState(PVR_TIMER_STATE_ABORTED);
-    else if (strstr(str, "missing") != nullptr)
-      rec.SetState(PVR_TIMER_STATE_ERROR);
 
-    rec.SetError(str);
+    rec.SetError(error);
   }
 
   /* A running recording will have an active subscription assigned to it */

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -2648,11 +2648,10 @@ void CTvheadend::ParseRecordingAddOrUpdate(htsmsg_t* msg, bool bAdd)
   /* Update */
   if (rec != comparison)
   {
-    std::string error = rec.GetError().empty() ? "none" : rec.GetError();
+    const std::string error = rec.GetError().empty() ? "n/a" : rec.GetError();
 
-    Logger::Log(LogLevel::LEVEL_DEBUG, "recording id:%d, state:%s, title:%s, desc:%s, error:%s",
-                rec.GetId(), state, rec.GetTitle().c_str(), rec.GetDescription().c_str(),
-                error.c_str());
+    Logger::Log(LogLevel::LEVEL_DEBUG, "recording id:%d, state:%s, title:%s, error:%s",
+                rec.GetId(), state, rec.GetTitle().c_str(), error.c_str());
 
     if (m_asyncState.GetState() > ASYNC_DVR)
     {


### PR DESCRIPTION
- Ignore recordings without a file (e.g. removed recordings).
- When parsing recording add/update messages, always set the correct error string.
- Reduce debug log spam. Do not log recording descriptions.