### PR TITLE
20.3.0: Inputstream API bump.

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="20.2.2"
+  version="20.3.0"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+v20.3.0
+- Inputstream API bump.
+
 v20.2.2
 - Fix deleted recordings not disappearing in Kodi until restart (regression introduced with v20.2.1)
 


### PR DESCRIPTION
Add-on needs recompile/relaese because of https://github.com/xbmc/xbmc/pull/20915.