### PR TITLE
[Nexus] Increase version to 20.4.0

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="20.3.0"
+  version="20.4.0"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+v20.4.0
+- Kodi inputstream API update to version 3.2.0
+
 v20.3.0
 - Inputstream API bump.
 


### PR DESCRIPTION
Bump version for inpustream API change
due to:
https://github.com/xbmc/xbmc/pull/21390
https://github.com/xbmc/xbmc/pull/21319
