### PR TITLE
[Omega] Fix TV channels stuttering after wake from suspend

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="21.1.0"
+  version="21.1.1"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+v21.1.1
+- Fix TV channels stuttering after wake from suspend
+
 v21.1.0
 - Kodi inputstream API update to version 3.3.0
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1881,6 +1881,10 @@ void CTvheadend::SyncInitCompleted()
     return;
 
   /* Rebuild state */
+  for (auto* dmx : m_dmx)
+    dmx->RebuildState();
+
+  m_vfs->RebuildState();
   m_timeRecordings.RebuildState();
   m_autoRecordings.RebuildState();
 
@@ -2017,11 +2021,6 @@ void CTvheadend::SyncEpgCompleted()
 
 void CTvheadend::SyncCompleted()
 {
-  for (auto* dmx : m_dmx)
-    dmx->RebuildState();
-
-  m_vfs->RebuildState();
-
   SyncEpgCompleted();
 
   m_asyncState.SetState(ASYNC_DONE);


### PR DESCRIPTION
Fixes a regression introduced with #615. 

We need to rebuild demuxer and vfs state early. Doing this when async update is done is to late, because async update can take several seconds and Kodi will try to resume playback early after wakeup from suspend.