### PR TITLE
Add support for TVH Parental Rating fields

### DIFF
--- a/src/tvheadend/HTSPConnection.cpp
+++ b/src/tvheadend/HTSPConnection.cpp
@@ -34,7 +34,7 @@ using namespace tvheadend::utilities;
 
 #define HTSP_MIN_SERVER_VERSION (26) // Server must support at least this htsp version
 #define HTSP_CLIENT_VERSION \
-  (35) // Client uses HTSP features up to this version. If the respective \
+  (37) // Client uses HTSP features up to this version. If the respective \
       // addon feature requires htsp features introduced after \
       // HTSP_MIN_SERVER_VERSION this feature will only be available if the \
       // actual server HTSP version matches (runtime htsp version check).

--- a/src/tvheadend/entity/Event.h
+++ b/src/tvheadend/entity/Event.h
@@ -56,7 +56,10 @@ public:
            m_recordingId == other.m_recordingId && m_seriesLink == other.m_seriesLink &&
            m_year == other.m_year && m_writers == other.m_writers &&
            m_directors == other.m_directors && m_cast == other.m_cast &&
-           m_categories == other.m_categories;
+           m_categories == other.m_categories &&
+           m_rating_label == other.m_rating_label &&
+           m_rating_icon == other.m_rating_icon &&
+           m_rating_source == other.m_rating_source;
   }
 
   bool operator!=(const Event& other) const { return !(*this == other); }
@@ -83,6 +86,15 @@ public:
 
   uint32_t GetAge() const { return m_age; }
   void SetAge(uint32_t age) { m_age = age; }
+
+  const std::string& GetRatingLabel() const { return m_rating_label; }
+  void SetRatingLabel(const std::string& ratingLabel) { m_rating_label = ratingLabel; }
+
+  const std::string& GetRatingIcon() const { return m_rating_icon; }
+  void SetRatingIcon(const std::string& ratingIcon) { m_rating_icon = ratingIcon; }
+
+  const std::string& GetRatingSource() const { return m_rating_source; }
+  void SetRatingSource(const std::string& ratingSource) { m_rating_source = ratingSource; }
 
   int32_t GetSeason() const { return m_season; }
   void SetSeason(int32_t season) { m_season = season; }
@@ -157,6 +169,9 @@ private:
   std::string m_cast;
   std::string m_categories;
   std::string m_aired;
+  std::string m_rating_label;  // Label like 'PG' or 'FSK 12'
+  std::string m_rating_icon;   // Path to graphic for the above label.
+  std::string m_rating_source; // Parental rating source.
 };
 
 } // namespace entity

--- a/src/tvheadend/entity/Recording.h
+++ b/src/tvheadend/entity/Recording.h
@@ -62,7 +62,8 @@ public:
       m_contentType(0),
       m_season(-1),
       m_episode(-1),
-      m_part(0)
+      m_part(0),
+      m_ageRating(0)
   {
   }
 
@@ -80,7 +81,10 @@ public:
            m_error == other.m_error && m_lifetime == other.m_lifetime &&
            m_priority == other.m_priority && m_playCount == other.m_playCount &&
            m_playPosition == other.m_playPosition && m_contentType == other.m_contentType &&
-           m_season == other.m_season && m_episode == other.m_episode && m_part == other.m_part;
+           m_season == other.m_season && m_episode == other.m_episode && m_part == other.m_part &&
+           m_ageRating == other.m_ageRating && m_ratingLabel == other.m_ratingLabel &&
+           m_ratingIcon == other.m_ratingIcon;
+           m_ratingSource == other.m_ratingSource;
   }
 
   bool operator!=(const Recording& other) const { return !(*this == other); }
@@ -210,6 +214,18 @@ public:
   uint32_t GetPart() const { return m_part; }
   void SetPart(uint32_t part) { m_part = part; }
 
+  void SetAgeRating(uint32_t content) { m_ageRating = content; }
+  uint32_t GetAgeRating() const { return m_ageRating; }
+
+  const std::string& GetRatingLabel() const { return m_ratingLabel; }
+  void SetRatingLabel(const std::string& ratingLabel) { m_ratingLabel = ratingLabel; }
+
+  const std::string& GetRatingIcon() const { return m_ratingIcon; }
+  void SetRatingIcon(const std::string& ratingIcon) { m_ratingIcon = ratingIcon; }
+
+  const std::string& GetRatingSource() const { return m_ratingSource; }
+  void SetRatingSource(const std::string& ratingSource) { m_ratingSource = ratingSource; }
+
 private:
   uint32_t m_enabled;
   uint32_t m_channel;
@@ -241,6 +257,10 @@ private:
   int32_t m_season;
   int32_t m_episode;
   uint32_t m_part;
+  uint32_t m_ageRating;
+  std::string m_ratingLabel;
+  std::string m_ratingIcon;
+  std::string m_ratingSource;
 };
 
 } // namespace entity


### PR DESCRIPTION
Process the existing ‘ageRating’ and the new ‘ratingLabel’ and ‘ratingIcon’ HTSP fields and pass them to the Kodi PVR module.

These fields will be accessible to skins as follows:

ageRating => $INFO[ListItem.ParentalRating]
ratingLabel => $INFO[ListItem.ParentalRatingCode]
ratingIcon => $INFO[ListItem.ParentalRatingIcon]

If ratingAuthority exists => $INFO[ListItem.ParentalRatingSource], otherwise, if ratingCountry exists => $INFO[ListItem.ParentalRatingSource].

**Note:**  The change requires acceptance of the Kodi core PR [#24096](https://github.com/xbmc/xbmc/pull/24096) containing the modifications to the PVR client API.