### PR TITLE
HTSPDemuxer: don't disconnect when demux read no data

### DIFF
--- a/src/tvheadend/HTSPDemuxer.cpp
+++ b/src/tvheadend/HTSPDemuxer.cpp
@@ -145,15 +145,6 @@ DEMUX_PACKET* HTSPDemuxer::Read()
     m_lastPkt.store(m_lastUse.load());
     return pkt;
   }
-  Logger::Log(LogLevel::LEVEL_TRACE, "demux read nothing");
-
-  if (m_lastPkt > 0 && m_lastUse - m_lastPkt > 10 && !IsPaused())
-  {
-    Logger::Log(LogLevel::LEVEL_WARNING,
-                "demux read no data for at least 10 secs; restarting connection");
-    m_lastPkt = 0;
-    m_conn.Disconnect();
-  }
   return m_demuxPktHdl.AllocateDemuxPacket(0);
 }
 


### PR DESCRIPTION
I had this very annoying issue - when watching an encrypted TV channel and descrambling would fail (for whatever reason, eg network problem) - I got a frozen video until I switch to another channel. "Restart on error" is enabled in tvh htsp profile but in that case it was useless because pvr.hts would close the connection and I end up with a frozen video even when descrambling is available again.

This PR fix that issue. Now when descrambling temporarily fails - the subscription would stay alive and streaming is resumed automatically, "Restart on error" tvh setting now works as it should.

With this PR:
```
2023-11-14 07:12:28.318 descrambler: cannot decode packets for service "Eurosport 1 NEE HD"
2023-11-14 07:12:29.914 subscription: 0004: service instance is bad, reason: No access
2023-11-14 07:14:04.272 subscription: 0004: restarting channel Eurosport 1 NEE HD
2023-11-14 07:14:06.214 mpegts: 10723V in Discovery Networks - tuning on STV090x Multistandard #0 : DVB-S #0
```
Without this PR:

```
2023-11-14 07:21:16.752 descrambler: cannot decode packets for service "Eurosport 1 NEE HD"
2023-11-14 07:21:18.086 subscription: 0001: service instance is bad, reason: No access
2023-11-14 07:21:20.086 subscription: 0001: restarting channel Eurosport 1 NEE HD
2023-11-14 07:21:20.183 htsp: 127.0.0.1 [  | Kodi Media Center ]: Disconnected
2023-11-14 07:21:20.183 subscription: 0001: "127.0.0.1 [  | Kodi Media Center ]" unsubscribing from "Eurosport 1 NEE HD", hostname="127.0.0.1", username="127.0.0.1", client="Kodi Media Center"
```
