### PR TITLE
Predictive tuning: Fix crash when starting playback

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="21.2.0"
+  version="21.2.1"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,7 @@
+v21.2.1
+- Predictive tuning: Fix crash when starting playback of a channel which has no unique channel number
+  (tvh does not prevent duplicate channel numbers).
+
 v21.2.0
 - Add setting for threshold for reconnect on stalled streams
 

--- a/src/tvheadend/ChannelTuningPredictor.h
+++ b/src/tvheadend/ChannelTuningPredictor.h
@@ -68,7 +68,11 @@ struct SortChannelPair
 {
   bool operator()(const ChannelPair& left, const ChannelPair& right) const
   {
-    return left.second < right.second;
+    if (left.second < right.second)
+      return true;
+
+    // if channel numbers are equal, consider channel id (which is unique)
+    return left.first < right.first;
   }
 };
 } // namespace predictivetune


### PR DESCRIPTION
Predictive tuning: Fix crash when starting playback of a channel which has no unique channel number

 Tvh does not prevent duplicate channel numbers. This led to not all channels being added to channel tuning predictors channel set `m_channel`. When a channel not in predictor's channel set was tuned, this led to deref of `m_channels.cend()` here: https://github.com/kodi-pvr/pvr.hts/blob/Omega/src/tvheadend/ChannelTuningPredictor.cpp#L62