### PR TITLE
Predictive tuning: Fix crash because of an invalid comparator

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="21.2.2"
+  version="21.2.3"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+v21.2.3
+- Predictive tuning: Fix crash while sorting channels.
+
 v21.2.2
 - Translations updates from Weblate
 	- af_za, am_et, ar_sa, ast_es, az_az, be_by, bg_bg, bs_ba, ca_es, cs_cz, cy_gb, da_dk, de_de, el_gr, en_au, en_nz, en_us, eo, es_ar, es_es, es_mx, et_ee, eu_es, fa_af, fa_ir, fi_fi, fo_fo, fr_ca, fr_fr, gl_es, he_il, hi_in, hr_hr, hu_hu, hy_am, id_id, is_is, it_it, ja_jp, ko_kr, lt_lt, lv_lv, mi, mk_mk, ml_in, mn_mn, ms_my, mt_mt, my_mm, nb_no, nl_nl, pl_pl, pt_br, pt_pt, ro_ro, ru_ru, si_lk, sk_sk, sl_si, sq_al, sr_rs, sr_rs@latin, sv_se, szl, ta_in, te_in, tg_tj, th_th, tr_tr, uk_ua, uz_uz, vi_vn, zh_cn, zh_tw

--- a/src/tvheadend/ChannelTuningPredictor.h
+++ b/src/tvheadend/ChannelTuningPredictor.h
@@ -70,6 +70,9 @@ struct SortChannelPair
   {
     if (left.second < right.second)
       return true;
+    
+    if (right.second < left.second)
+      return false;
 
     // if channel numbers are equal, consider channel id (which is unique)
     return left.first < right.first;


### PR DESCRIPTION
The compare function violated the antisymmetry. (Counter)example:
![grafik](https://github.com/kodi-pvr/pvr.hts/assets/2150851/cd776022-76f2-4609-8b92-7a2b6db84ce3)
