### PR TITLE
 Async updates: Ignore 'add' events for existing tags (happens on wake after suspend)

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="21.2.3"
+  version="21.2.4"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+v21.2.4
+-  Async updates: Ignore 'add' events for existing tags (happens on wake after suspend).
+
 v21.2.3
 - Predictive tuning: Fix crash while sorting channels.
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -2049,6 +2049,12 @@ void CTvheadend::ParseTagAddOrUpdate(htsmsg_t* msg, bool bAdd)
   }
 
   /* Locate object */
+  if (bAdd && m_tags.find(u32) != m_tags.cend())
+  {
+    Logger::Log(LogLevel::LEVEL_DEBUG, "Ignoring 'addTag' for existing tag with id %d", u32);
+    return;
+  }
+
   auto& existingTag = m_tags[u32];
   existingTag.SetDirty(false);
 


### PR DESCRIPTION
Fixes a race on wakeup after suspend, where actually existing channels were not reported to Kodi, thus removed from Kodi's TV database.