### PR TITLE
Fix custom prop logspam

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="22.4.0"
+  version="22.4.1"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,5 +1,6 @@
 v22.4.1
 - Fix pointless "Unknown property" log spam introduced with v22.4.0
+- Fix update of "DVR configuration" property not working
 
 v22.4.0
 - PVR Add-on API v9.1.0

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+v22.4.1
+- Fix pointless "Unknown property" log spam introduced with v22.4.0
+
 v22.4.0
 - PVR Add-on API v9.1.0
 - Add support for Autorec property "Broadcast type" (HTSPv39+)

--- a/src/tvheadend/CustomTimerProperties.cpp
+++ b/src/tvheadend/CustomTimerProperties.cpp
@@ -33,6 +33,10 @@ std::vector<kodi::addon::PVRSettingKeyValuePair> CustomTimerProperties::GetPrope
 {
   std::vector<kodi::addon::PVRSettingKeyValuePair> customProps;
   GetCommonProperties(customProps, rec);
+
+  if (customProps.size() < m_propIds.size())
+    Logger::Log(LogLevel::LEVEL_ERROR, "Not all properties handled!");
+
   return customProps;
 }
 
@@ -55,10 +59,13 @@ std::vector<kodi::addon::PVRSettingKeyValuePair> CustomTimerProperties::GetPrope
         break;
       }
       default:
-        Logger::Log(LogLevel::LEVEL_ERROR, "Unknown property %u", propId);
         break;
     }
   }
+
+  if (customProps.size() < m_propIds.size())
+    Logger::Log(LogLevel::LEVEL_ERROR, "Not all properties handled!");
+
   return customProps;
 }
 
@@ -85,14 +92,11 @@ void CustomTimerProperties::GetCommonProperties(
       {
         // User comment
         if (m_conn.GetProtocol() >= 42)
-        {
-          /* user comment */
           props.emplace_back(CUSTOM_PROP_ID_DVR_COMMENT, rec.GetComment());
-          break;
-        }
+
+        break;
       }
       default:
-        Logger::Log(LogLevel::LEVEL_ERROR, "Unknown property %u", propId);
         break;
     }
   }
@@ -189,7 +193,6 @@ const std::vector<kodi::addon::PVRTypeIntValue> CustomTimerProperties::GetPossib
       // DVR configuration
       if (m_conn.GetProtocol() >= 40)
       {
-        // DVR configuration
         std::vector<kodi::addon::PVRTypeIntValue> dvrConfigValues;
         for (const auto& entry : m_dvrConfigs)
         {

--- a/src/tvheadend/entity/Recording.h
+++ b/src/tvheadend/entity/Recording.h
@@ -58,8 +58,7 @@ public:
            m_contentType == other.m_contentType && m_season == other.m_season &&
            m_episode == other.m_episode && m_part == other.m_part &&
            m_ageRating == other.m_ageRating && m_ratingLabel == other.m_ratingLabel &&
-           m_ratingIcon == other.m_ratingIcon && m_ratingSource == other.m_ratingSource &&
-           m_configUuid == other.m_configUuid;
+           m_ratingIcon == other.m_ratingIcon && m_ratingSource == other.m_ratingSource;
   }
 
   bool operator!=(const Recording& other) { return !(*this == other); }
@@ -186,9 +185,6 @@ public:
   const std::string& GetRatingSource() const { return m_ratingSource; }
   void SetRatingSource(const std::string& ratingSource) { m_ratingSource = ratingSource; }
 
-  const std::string& GetConfigUuid() const { return m_configUuid; }
-  void SetConfigUuid(const std::string& uuid) { m_configUuid = uuid; }
-
 private:
   uint32_t m_channelType{0};
   std::string m_channelName;
@@ -219,7 +215,6 @@ private:
   std::string m_ratingLabel;
   std::string m_ratingIcon;
   std::string m_ratingSource;
-  std::string m_configUuid; // DVR configuration UUID.
 };
 
 } // namespace tvheadend::entity


### PR DESCRIPTION
First commit fixes  some log spam introduced with v22..4.0 . There is no dysfaction, only log flooded with pointless entries. 

Second commit fixes fallout from refactoring recordings entity class hierarchy. Member `m_configUui` belongs into base class `RecordingBase` only, but somehow in derived class `Recording`another member with this name and type sneaked in during refactoring, leading to writing values to base class member, but reading from derived class member. This prevented proper updating the property.

Plus, some cosmetics along the way.