### PR TITLE
Fix build with gcc-15

### DIFF
--- a/src/tvheadend/HTSPVFS.h
+++ b/src/tvheadend/HTSPVFS.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 
 namespace kodi
 {


### PR DESCRIPTION
Fixes

```
[44/46] Building CXX object CMakeFiles/pvr.hts.dir/src/tvheadend/HTSPVFS.cpp.o
FAILED: CMakeFiles/pvr.hts.dir/src/tvheadend/HTSPVFS.cpp.o 
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-g++ -DADDON_GLOBAL_VERSION_GENERAL_USED -DADDON_GLOBAL_VERSION_MAIN_USED -DADDON_GLOBAL_VERSION_NETWORK_USED -DADDON_GLOBAL_VERSION_TOOLS_USED -DADDON_INSTANCE_VERSION_INPUTSTREAM_USED -DADDON_INSTANCE_VERSION_PVR_USED -DBUILD_KODI_ADDON -Dpvr_hts_EXPORTS -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/pvr.hts-22.6.0-Piers/lib -march=x86-64-v3 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -std=c++17 -fPIC   -DTARGET_POSIX -DTARGET_LINUX -D_GNU_SOURCE -DHAVE_LINUX_UDMABUF=1 -DHAVE_LINUX_DMA_HEAP=1 -DHAVE_LINUX_DMA_BUF=1 -DHAVE_MKOSTEMP=1 -DHAVE_LINUX_MEMFD=1 -DHAVE_STATX=1 -DHAVE_SSE=1 -DHAVE_SSE2=1 -DHAVE_SSE3=1 -DHAVE_SSSE3=1 -DHAVE_SSE4_1=1 -MD -MT CMakeFiles/pvr.hts.dir/src/tvheadend/HTSPVFS.cpp.o -MF CMakeFiles/pvr.hts.dir/src/tvheadend/HTSPVFS.cpp.o.d -o CMakeFiles/pvr.hts.dir/src/tvheadend/HTSPVFS.cpp.o -c /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/pvr.hts-22.6.0-Piers/src/tvheadend/HTSPVFS.cpp
In file included from ../src/tvheadend/HTSPVFS.cpp:8:
../src/tvheadend/HTSPVFS.h:36:3: error: 'uint32_t' does not name a type
   36 |   uint32_t GetFileId() const { return m_fileId; }
      |   ^~~~~~~~
../src/tvheadend/HTSPVFS.h:12:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   11 | #include <string>
  +++ |+#include <cstdint>
   12 | 
../src/tvheadend/HTSPVFS.h:59:3: error: 'uint32_t' does not name a type
   59 |   uint32_t m_fileId;
      |   ^~~~~~~~
../src/tvheadend/HTSPVFS.h:59:3: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
``` 