### PR TITLE
Add support for 'Is New' flag on EPG events

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="22.6.3"
+  version="22.7.0"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,6 @@
+v22.7.0
+- Add support for isNew flag on EPG events
+
 v22.6.3
 - Fix profile parameter not encoded in http(s) URLs
 

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1508,6 +1508,9 @@ void CTvheadend::CreateEvent(const Event& event, kodi::addon::PVREPGTag& epg)
   epg.SetEpisodeNumber(event.GetEpisode());
   epg.SetEpisodePartNumber(event.GetPart());
   epg.SetFlags(EPG_TAG_FLAG_UNDEFINED);
+  if (event.GetIsNew())
+    epg.SetFlags(EPG_TAG_FLAG_IS_NEW);
+
   epg.SetSeriesLink(event.GetSeriesLink());
 }
 
@@ -3036,6 +3039,8 @@ bool CTvheadend::ParseEvent(htsmsg_t* msg, bool bAdd, Event& evt)
     evt.SetEpisode(static_cast<int32_t>(u32));
   if (!htsmsg_get_u32(msg, "partNumber", &u32))
     evt.SetPart(u32);
+  if (!htsmsg_get_u32(msg, "isNew", &u32))
+    evt.SetIsNew(u32);
 
   str = htsmsg_get_str(msg, "serieslinkUri");
   if (str)

--- a/src/tvheadend/entity/Event.h
+++ b/src/tvheadend/entity/Event.h
@@ -41,7 +41,8 @@ public:
       m_episode(-1),
       m_part(-1),
       m_recordingId(0),
-      m_year(0)
+      m_year(0),
+      m_isnew(0)
   {
   }
 
@@ -57,7 +58,8 @@ public:
            m_year == other.m_year && m_writers == other.m_writers &&
            m_directors == other.m_directors && m_cast == other.m_cast &&
            m_categories == other.m_categories && m_ratingLabel == other.m_ratingLabel &&
-           m_ratingIcon == other.m_ratingIcon && m_ratingSource == other.m_ratingSource;
+           m_ratingIcon == other.m_ratingIcon && m_ratingSource == other.m_ratingSource &&
+           m_isnew == other.m_isnew;
   }
 
   bool operator!=(const Event& other) const { return !(*this == other); }
@@ -143,6 +145,9 @@ public:
   const std::string& GetAired() const { return m_aired; }
   void SetAired(time_t aired);
 
+  uint32_t GetIsNew() const { return m_isnew; }
+  void SetIsNew(uint32_t isnew) { m_isnew = isnew; }
+
 private:
   uint32_t m_next;
   uint32_t m_channel;
@@ -170,6 +175,7 @@ private:
   std::string m_ratingLabel; // Label like 'PG' or 'FSK 12'
   std::string m_ratingIcon; // Path to graphic for the above label.
   std::string m_ratingSource; // Parental rating source.
+  uint32_t m_isnew;
 };
 
 } // namespace entity


### PR DESCRIPTION
The 'isNew' value is now parsed from incoming event messages and stored within the Event entity. When set, it triggers the EPG_TAG_FLAG_IS_NEW flag in the generated Kodi EPG tag, allowing Kodi to distinguish newly broadcast content from repeats.

Kodi has supported the EPG_TAG_FLAG_IS_NEW flag for some time, as defined in its PVR API at:
xbmc/addons/kodi-addon-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h, line 123.

Therefore, no changes are required to Kodi itself or to the PVR API.

This enhancement is entirely confined to the pvr.hts addon.