### PR TITLE
Fix compilation in armv7 with gcc15

### DIFF
--- a/src/tvheadend/HTSPVFS.h
+++ b/src/tvheadend/HTSPVFS.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <memory>
+#include <cstdint>
 #include <string>
 
 namespace kodi


### PR DESCRIPTION
Fixes compilation in armv7 Kodi Omega / pvr.hts Omega branch (both on latest)

Full log:
[log.txt](https://github.com/user-attachments/files/23898276/log.txt)

Same issue in Piers as well, @ksooo @garbear 

Fixes: https://github.com/kodi-pvr/pvr.hts/issues/656
