### PR TITLE
New setting: Use backend settings for recording folder creation

### DIFF
--- a/pvr.hts/addon.xml.in
+++ b/pvr.hts/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="22.8.2"
+  version="22.9.0"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp, Kai Sommerfeld">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.hts/changelog.txt
+++ b/pvr.hts/changelog.txt
@@ -1,3 +1,7 @@
+v22.9.0
+- Add setting "Use backend settings for recording folder creation"
+  When enabled, do not send recording folder to backend for autorecs and timerecs
+
 v22.8.2
 - Translations updates from Weblate
 - Fix compilation on armv7 with gcc15

--- a/pvr.hts/resources/instance-settings.xml
+++ b/pvr.hts/resources/instance-settings.xml
@@ -245,6 +245,11 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
+        <setting id="dvr_use_backend_folder_creation" type="boolean" label="30391" help="-1">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle"/>
+        </setting>
       </group>
     </category>
 

--- a/pvr.hts/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.hts/resources/language/resource.language.en_gb/strings.po
@@ -383,7 +383,12 @@ msgctxt "#30390"
 msgid "Use backend setting"
 msgstr ""
 
-#empty strings from id 30391 to 30399
+#. When enabled, do not send recording folder to backend, let it use its own folder settings
+msgctxt "#30391"
+msgid "Use backend settings for recording folder creation"
+msgstr ""
+
+#empty strings from id 30392 to 30399
 
 msgctxt "#30400"
 msgid "Predictive tuning"

--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -39,7 +39,7 @@ CTvheadend::CTvheadend(const kodi::addon::IInstanceInfo& instance)
     m_streamchange(false),
     m_queue(static_cast<size_t>(-1)),
     m_asyncState(m_settings->GetResponseTimeout()),
-    m_timeRecordings(*m_conn, m_dvrConfigs),
+    m_timeRecordings(m_settings, *m_conn, m_dvrConfigs),
     m_autoRecordings(m_settings, *m_conn, m_dvrConfigs),
     m_epgMaxDays(EpgMaxFutureDays()),
     m_playingLiveStream(false)
@@ -1096,7 +1096,10 @@ PVR_ERROR CTvheadend::GetTimerTypes(std::vector<kodi::addon::PVRTimerType>& type
           PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
           PVR_TIMER_TYPE_SUPPORTS_START_TIME | PVR_TIMER_TYPE_SUPPORTS_END_TIME |
           PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS | PVR_TIMER_TYPE_SUPPORTS_PRIORITY |
-          PVR_TIMER_TYPE_SUPPORTS_LIFETIME | PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS,
+          PVR_TIMER_TYPE_SUPPORTS_LIFETIME |
+          (m_settings->GetDvrUseBackendFolderCreation()
+               ? 0
+               : PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS),
       /* Let Kodi generate the description. */
       "",
       /* Custom settings definitions. */
@@ -1116,7 +1119,9 @@ PVR_ERROR CTvheadend::GetTimerTypes(std::vector<kodi::addon::PVRTimerType>& type
         PVR_TIMER_TYPE_IS_REPEATING | PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
         PVR_TIMER_TYPE_SUPPORTS_CHANNELS | PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS |
         PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN | PVR_TIMER_TYPE_SUPPORTS_PRIORITY |
-        PVR_TIMER_TYPE_SUPPORTS_LIFETIME | PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS |
+        PVR_TIMER_TYPE_SUPPORTS_LIFETIME |
+        (m_settings->GetDvrUseBackendFolderCreation() ? 0
+                                                      : PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS) |
         PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL | PVR_TIMER_TYPE_REQUIRES_EPG_SERIESLINK_ON_CREATE;
 
     /* Repeating epg based - series link autorec */
@@ -1142,8 +1147,10 @@ PVR_ERROR CTvheadend::GetTimerTypes(std::vector<kodi::addon::PVRTimerType>& type
       PVR_TIMER_TYPE_SUPPORTS_TITLE_EPG_MATCH | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
       PVR_TIMER_TYPE_SUPPORTS_WEEKDAYS | PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN |
       PVR_TIMER_TYPE_SUPPORTS_PRIORITY | PVR_TIMER_TYPE_SUPPORTS_LIFETIME |
-      PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS | PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL |
-      PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH | PVR_TIMER_TYPE_SUPPORTS_RECORD_ONLY_NEW_EPISODES;
+      (m_settings->GetDvrUseBackendFolderCreation() ? 0
+                                                    : PVR_TIMER_TYPE_SUPPORTS_RECORDING_FOLDERS) |
+      PVR_TIMER_TYPE_SUPPORTS_ANY_CHANNEL | PVR_TIMER_TYPE_SUPPORTS_FULLTEXT_EPG_MATCH |
+      PVR_TIMER_TYPE_SUPPORTS_RECORD_ONLY_NEW_EPISODES;
 
   /* Repeating epg based - autorec */
   types.emplace_back(TimerType(

--- a/src/tvheadend/AutoRecordings.cpp
+++ b/src/tvheadend/AutoRecordings.cpp
@@ -192,7 +192,7 @@ PVR_ERROR AutoRecordings::SendAutorecAddOrUpdate(const kodi::addon::PVRTimer& ti
   /* Note: As a result of internal filename cleanup, for "directory" == "/", */
   /*       tvh would put recordings into a folder named "-". Not a big issue */
   /*       but ugly.                                                         */
-  if (timer.GetDirectory() != "/")
+  if (timer.GetDirectory() != "/" && !m_settings->GetDvrUseBackendFolderCreation())
     htsmsg_add_str(m, "directory", timer.GetDirectory().c_str());
 
   /* series link */

--- a/src/tvheadend/InstanceSettings.cpp
+++ b/src/tvheadend/InstanceSettings.cpp
@@ -39,6 +39,7 @@ const int DEFAULT_DVR_DUPDETECT = DVR_AUTOREC_RECORD_ALL;
 const bool DEFAULT_DVR_PLAYSTATUS = true;
 const int DEFAULT_STREAM_CHUNKSIZE = 64; // KB
 const bool DEFAULT_DVR_IGNORE_DUPLICATE_SCHEDULES = true;
+const bool DEFAULT_DVR_USE_BACKEND_FOLDER_CREATION = false;
 const int DEFAULT_STREAM_STALLED_THRESHOLD = 10; // seconds
 
 } // namespace
@@ -67,6 +68,7 @@ InstanceSettings::InstanceSettings(kodi::addon::IAddonInstance& instance)
     m_bDvrPlayStatus(DEFAULT_DVR_PLAYSTATUS),
     m_iStreamReadChunkSizeKB(DEFAULT_STREAM_CHUNKSIZE),
     m_bIgnoreDuplicateSchedules(DEFAULT_DVR_IGNORE_DUPLICATE_SCHEDULES),
+    m_bDvrUseBackendFolderCreation(DEFAULT_DVR_USE_BACKEND_FOLDER_CREATION),
     m_streamStalledThreshold(DEFAULT_STREAM_STALLED_THRESHOLD)
 {
   ReadSettings();
@@ -119,6 +121,9 @@ void InstanceSettings::ReadSettings()
   /* Scheduled recordings */
   SetIgnoreDuplicateSchedules(
       ReadBoolSetting("dvr_ignore_duplicates", DEFAULT_DVR_IGNORE_DUPLICATE_SCHEDULES));
+
+  SetDvrUseBackendFolderCreation(
+      ReadBoolSetting("dvr_use_backend_folder_creation", DEFAULT_DVR_USE_BACKEND_FOLDER_CREATION));
 }
 
 ADDON_STATUS InstanceSettings::SetSetting(const std::string& key,
@@ -192,6 +197,8 @@ ADDON_STATUS InstanceSettings::SetSetting(const std::string& key,
     return SetBoolSetting(GetDvrPlayStatus(), value);
   else if (key == "stream_readchunksize")
     return SetIntSetting(GetStreamReadChunkSize(), value);
+  else if (key == "dvr_use_backend_folder_creation")
+    return SetBoolSetting(GetDvrUseBackendFolderCreation(), value);
   else if (key == "dvr_ignore_duplicates")
   {
     SetIgnoreDuplicateSchedules(value.GetBoolean());

--- a/src/tvheadend/InstanceSettings.h
+++ b/src/tvheadend/InstanceSettings.h
@@ -51,6 +51,7 @@ public:
   bool GetDvrPlayStatus() const { return m_bDvrPlayStatus; }
   int GetStreamReadChunkSize() const { return m_iStreamReadChunkSizeKB; }
   bool GetIgnoreDuplicateSchedules() const { return m_bIgnoreDuplicateSchedules; }
+  bool GetDvrUseBackendFolderCreation() const { return m_bDvrUseBackendFolderCreation; }
   int GetStreamStalledThreshold() const { return m_streamStalledThreshold; }
 
 private:
@@ -86,6 +87,7 @@ private:
   void SetDvrPlayStatus(bool value) { m_bDvrPlayStatus = value; }
   void SetStreamReadChunkSizeKB(int value) { m_iStreamReadChunkSizeKB = value; }
   void SetIgnoreDuplicateSchedules(bool value) { m_bIgnoreDuplicateSchedules = value; }
+  void SetDvrUseBackendFolderCreation(bool value) { m_bDvrUseBackendFolderCreation = value; }
   void SetStreamStalledThreshold(int value) { m_streamStalledThreshold = value; }
 
   /**
@@ -125,6 +127,7 @@ private:
   bool m_bDvrPlayStatus;
   int m_iStreamReadChunkSizeKB;
   bool m_bIgnoreDuplicateSchedules;
+  bool m_bDvrUseBackendFolderCreation;
   int m_streamStalledThreshold; // seconds
 };
 

--- a/src/tvheadend/TimeRecordings.cpp
+++ b/src/tvheadend/TimeRecordings.cpp
@@ -9,6 +9,7 @@
 
 #include "CustomTimerProperties.h"
 #include "HTSPConnection.h"
+#include "InstanceSettings.h"
 #include "entity/Recording.h"
 #include "utilities/LifetimeMapper.h"
 #include "utilities/Logger.h"
@@ -21,8 +22,11 @@ using namespace tvheadend;
 using namespace tvheadend::entity;
 using namespace tvheadend::utilities;
 
-TimeRecordings::TimeRecordings(HTSPConnection& conn, Profiles& dvrConfigs)
-  : m_conn(conn),
+TimeRecordings::TimeRecordings(const std::shared_ptr<InstanceSettings>& settings,
+                               HTSPConnection& conn,
+                               Profiles& dvrConfigs)
+  : m_settings(settings),
+    m_conn(conn),
     m_customTimerProps(
         {CUSTOM_PROP_ID_DVR_CONFIGURATION, CUSTOM_PROP_ID_DVR_COMMENT}, conn, dvrConfigs)
 {
@@ -174,7 +178,7 @@ PVR_ERROR TimeRecordings::SendTimerecAddOrUpdate(const kodi::addon::PVRTimer& ti
   /* Note: As a result of internal filename cleanup, for "directory" == "/", */
   /*       tvh would put recordings into a folder named "-". Not a big issue */
   /*       but ugly.                                                         */
-  if (timer.GetDirectory() != "/")
+  if (timer.GetDirectory() != "/" && !m_settings->GetDvrUseBackendFolderCreation())
     htsmsg_add_str(m, "directory", timer.GetDirectory().c_str());
 
   /* Custom props. */

--- a/src/tvheadend/TimeRecordings.h
+++ b/src/tvheadend/TimeRecordings.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 extern "C"
@@ -26,11 +27,14 @@ namespace tvheadend
 {
 
 class HTSPConnection;
+class InstanceSettings;
 
 class TimeRecordings
 {
 public:
-  TimeRecordings(HTSPConnection& conn, Profiles& dvrConfigs);
+  TimeRecordings(const std::shared_ptr<InstanceSettings>& settings,
+                 HTSPConnection& conn,
+                 Profiles& dvrConfigs);
   ~TimeRecordings();
 
   /* state updates */
@@ -59,6 +63,7 @@ private:
   HTSPConnection& m_conn;
   const tvheadend::CustomTimerProperties m_customTimerProps;
   tvheadend::entity::TimeRecordingsMap m_timeRecordings;
+  std::shared_ptr<InstanceSettings> m_settings;
 };
 
 } // namespace tvheadend


### PR DESCRIPTION
Fixes #740 

> What would work is a client setting that disabled the recording folder timer settings field completely, resulting in what you want, server settings being used, but in case you want to intentionally override server side behavior you will not be able to do so (due to no input field for the name being available)

I decided to go with this approach. 

Introduces a new add-on setting to control recording folder creation. 

If deactivated, behavior is unchanged. Kodi will create a folder name and send it to the backend when a timer rule is created/edited. User can change the folder name using the respective text input field in the timer rule settings.

If activated, timer rule settings will not contain above mentioned text input field for recording folder name. folders will be created according to the backend's recording profile settings.