### PR TITLE
Fix crash on wake-from-sleep: GetEPGForChannel bypasses connection-ready check

### DIFF
--- a/src/Tvheadend.cpp
+++ b/src/Tvheadend.cpp
@@ -1564,7 +1564,7 @@ PVR_ERROR CTvheadend::GetEPGForChannel(int channelUid,
   {
     std::unique_lock<std::recursive_mutex> lock(m_conn->Mutex());
 
-    msg = m_conn->SendAndWait0(lock, "getEvents", msg);
+    msg = m_conn->SendAndWait(lock, "getEvents", msg);
     if (!msg)
       return PVR_ERROR_SERVER_ERROR;
   }

--- a/src/tvheadend/HTSPConnection.cpp
+++ b/src/tvheadend/HTSPConnection.cpp
@@ -243,6 +243,8 @@ void HTSPConnection::OnWake()
 
   /* recreate connection */
   m_suspended = false;
+
+  m_wakeCond.notify_all();
 }
 
 void HTSPConnection::SetState(PVR_CONNECTION_STATE state)
@@ -681,10 +683,12 @@ void HTSPConnection::Process()
       }
     }
 
-    while (m_suspended && !ShouldStopProcessing())
     {
-      /* Wait for wakeup */
-      Sleep(1000);
+      std::unique_lock<std::recursive_mutex> lock(m_mutex);
+      while (m_suspended && !ShouldStopProcessing())
+      {
+        m_wakeCond.wait_for(lock, std::chrono::milliseconds(1000));
+      }
     }
 
     if (ShouldStopProcessing())

--- a/src/tvheadend/HTSPConnection.h
+++ b/src/tvheadend/HTSPConnection.h
@@ -116,6 +116,7 @@ private:
   mutable std::recursive_mutex m_mutex;
   HTSPRegister* m_regThread;
   std::condition_variable_any m_regCond;
+  std::condition_variable_any m_wakeCond;
   bool m_ready;
   uint32_t m_seq;
   std::string m_serverName;


### PR DESCRIPTION
- Problem

Kodi [crashes](https://gist.github.com/smp79/2d656b0e725ab34e8eb5554b6c3e359d) shortly after resuming from sleep, with a SIGSEGV inside std::_Rb_tree_decrement. The crash occurs on the HTSPRegister handshake thread, corrupting HTSPConnection::m_messages (a std::map<uint32_t, HTSPResponse*>).

- Root cause

CTvheadend::GetEPGForChannel() sends its getEvents request via HTSPConnection::SendAndWait0(), which skips the "wait until the connection is ready" check (WaitForConnection()). Every other regular runtime call (subscribe, fileRead, timer/autorec add-delete, etc.) goes through SendAndWait() instead, which does wait.

SendAndWait0 is only meant to be used from inside the handshake itself (Hello/Auth), or from explicit "force" retry paths — not from a call Kodi's PVR/EPG manager repeats for every channel throughout the connection's lifetime.

On wake from sleep, OnWake() clears m_suspended but the connection thread only notices via a Sleep(1000) poll, so there's up to a ~1 second window where the pre-sleep socket is still closed. During that window, Kodi's EPG manager immediately calls GetEPGForChannel() for every channel. Each call:

Writes to the dead socket and fails.
SendMessage0() reacts by calling Disconnect() internally.

This repeats dozens of times in rapid succession, racing with the connection thread concurrently tearing down/recreating the socket and spawning a new HTSPRegister thread — corrupting m_messages and crashing.

- Fix

GetEPGForChannel() now uses SendAndWait() instead of SendAndWait0(), so it blocks until the connection is actually ready instead of writing straight to a stale socket.
OnWake() now signals a new m_wakeCond condition variable, and Process()'s suspend-wait loop blocks on it (with a 1s timeout as a safety net) instead of polling via Sleep(1000). This shrinks the reconnect-after-wake window from up to 1 second to effectively immediate, as defense in depth for any other caller that could hit the same race.
