### PR TITLE
HTSPDemuxer: re-announce stream change on subscription recovery

### DIFF
--- a/src/tvheadend/HTSPDemuxer.cpp
+++ b/src/tvheadend/HTSPDemuxer.cpp
@@ -447,13 +447,31 @@ void HTSPDemuxer::ResetStatus(bool resetSubscriptionData /* = true */)
  * Parse incoming data
  * *************************************************************************/
 
+void HTSPDemuxer::ProcessSubscriptionStatus(htsmsg_t* m)
+{
+  const eSubsriptionState prevState = m_subscription.GetState();
+
+  m_subscription.ParseSubscriptionStatus(m);
+
+  if (prevState != SUBSCRIPTION_RUNNING && m_subscription.GetState() == SUBSCRIPTION_RUNNING)
+  {
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
+    Logger::Log(LogLevel::LEVEL_DEBUG, "demux stream change (subscription recovered)");
+
+    DEMUX_PACKET* pkt = m_demuxPktHdl.AllocateDemuxPacket(0);
+    pkt->iStreamId = DEMUX_SPECIALID_STREAMCHANGE;
+    m_pktBuffer.Push(pkt);
+  }
+}
+
 bool HTSPDemuxer::ProcessMessage(const std::string& method, htsmsg_t* m)
 {
   /* Subscription messages */
   if (method == "muxpkt")
     ParseMuxPacket(m);
   else if (method == "subscriptionStatus")
-    m_subscription.ParseSubscriptionStatus(m);
+    ProcessSubscriptionStatus(m);
   else if (method == "queueStatus")
     ParseQueueStatus(m);
   else if (method == "signalStatus")

--- a/src/tvheadend/HTSPDemuxer.h
+++ b/src/tvheadend/HTSPDemuxer.h
@@ -102,6 +102,7 @@ private:
   void ParseMuxPacket(htsmsg_t* m);
   void ParseSourceInfo(htsmsg_t* m);
   void ParseSubscriptionStart(htsmsg_t* m);
+  void ProcessSubscriptionStatus(htsmsg_t* m);
   void ParseSubscriptionStop(htsmsg_t* m);
   void ParseSubscriptionSkip(htsmsg_t* m);
   void ParseSubscriptionSpeed(htsmsg_t* m);


### PR DESCRIPTION
### Problem

When a live channel's signal drops and recovers (`subscriptionStatus` reporting `badSignal` and then clearing), Tvheadend does **not** send a new`subscriptionStart` — it's the same HTSP subscription throughout. If Kodi had dropped the video stream while the signal was out, **it may stay stuck in audio-only (Radio) mode indefinitely** after the signal comes back, because nothing tells it a video stream may be available again.

### Fix

`Subscription::ParseSubscriptionStatus()` already tracks the transition between error states (`SUBSCRIPTION_NOSIGNAL`, `SUBSCRIPTION_SCRAMBLED`, etc.) and `SUBSCRIPTION_RUNNING`, but only updates internal state. This adds a thin
wrapper, `HTSPDemuxer::ProcessSubscriptionStatus()`, that detects the error → `SUBSCRIPTION_RUNNING` transition and pushes the same `DEMUX_SPECIALID_STREAMCHANGE` marker that a real channel switch already sends via `ParseSubscriptionStart()`. This routes through Kodi's stream-change handling in `CVideoPlayer::Process()`, which re-queries the current stream set and reselects defaults — recovering video if it's actually present again.

